### PR TITLE
Extend search 1 ply when entering a pawn endgame

### DIFF
--- a/src/main/java/com/kelseyde/calvin/board/Board.java
+++ b/src/main/java/com/kelseyde/calvin/board/Board.java
@@ -409,7 +409,7 @@ public class Board {
     }
 
     public boolean isPawnEndgame() {
-        return whitePawns != 0 && blackPawns != 0
+        return (whitePawns != 0 || blackPawns != 0)
                 && whiteKnights == 0 && blackKnights == 0
                 && whiteBishops == 0 && blackBishops == 0
                 && whiteRooks == 0 && blackRooks == 0

--- a/src/main/java/com/kelseyde/calvin/board/Board.java
+++ b/src/main/java/com/kelseyde/calvin/board/Board.java
@@ -408,4 +408,12 @@ public class Board {
                 Bitwise.countBits(blackRooks) > 0 || Bitwise.countBits(blackQueens) > 0;
     }
 
+    public boolean isPawnEndgame() {
+        return whitePawns != 0 && blackPawns != 0
+                && whiteKnights == 0 && blackKnights == 0
+                && whiteBishops == 0 && blackBishops == 0
+                && whiteRooks == 0 && blackRooks == 0
+                && whiteQueens == 0 && blackQueens == 0;
+    }
+
 }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -278,7 +278,8 @@ public class Searcher implements Search {
             }
 
             Move move = moves.get(i);
-            boolean isCapture = board.pieceAt(move.getEndSquare()) != null;
+            Piece capturedPiece = board.pieceAt(move.getEndSquare());
+            boolean isCapture = capturedPiece != null;
             boolean isPromotion = move.getPromotionPiece() != null;
 
             board.makeMove(move);
@@ -304,6 +305,11 @@ public class Searcher implements Search {
             // extend the search depth by one ply.
             int extension = 0;
             if (isPromotion || (isCheck && see.evaluateAfterMove(board, move) >= 0)) {
+                extension = 1;
+            }
+
+            // Extend search 1 ply when entering a pawn endgame, to avoid accidentally trading into lost/drawn endgames
+            if (isCapture && capturedPiece != Piece.PAWN && board.isPawnEndgame()) {
                 extension = 1;
             }
 


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 3297 - 3137 - 1774  [0.510] 8208
Terminating process of engine Calvin(5)
Finished game 8218 (Calvin vs Calvin DEV): * {No result}
Score of Calvin DEV vs Calvin: 3297 - 3137 - 1774  [0.510] 8208
...      Calvin DEV playing White: 1722 - 1513 - 870  [0.525] 4105
...      Calvin DEV playing Black: 1575 - 1624 - 904  [0.494] 4103
...      White vs Black: 3346 - 3088 - 1774  [0.516] 8208
Elo difference: 6.8 +/- 6.6, LOS: 97.7 %, DrawRatio: 21.6 %
```