### PR TITLE
Increase nmp reduction to 1 + (2 + depth / 3)

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -269,7 +269,7 @@ public class Searcher implements Search {
                 && staticEval >= beta - (config.getNmpMargin() * (improving ? 1 : 0))
                 && board.hasPiecesRemaining(board.isWhiteToMove())) {
                 board.makeNullMove();
-                int eval = -search(depth - 1 - (2 + depth / 7), ply + 1, -beta, -beta + 1, false);
+                int eval = -search(depth - 1 - (2 + depth / 3), ply + 1, -beta, -beta + 1, false);
                 board.unmakeNullMove();
                 if (eval >= beta) {
                     transpositionTable.put(getKey(), HashFlag.LOWER, depth, ply, previousBestMove, staticEval, beta);


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 289 - 225 - 849  [0.523] 1363
...      Calvin DEV playing White: 221 - 63 - 398  [0.616] 682
...      Calvin DEV playing Black: 68 - 162 - 451  [0.431] 681
...      White vs Black: 383 - 131 - 849  [0.592] 1363
Elo difference: 16.3 +/- 11.3, LOS: 99.8 %, DrawRatio: 62.3 %
```