### PR TITLE
Stop searching first PV node with null window

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -349,7 +349,7 @@ public class Searcher implements Search {
             if (isDraw()) {
                 eval = Score.DRAW;
             }
-            else if (pvNode && movesSearched == 0) {
+            else if (pvNode && movesSearched == 1) {
                 // Principal Variation Search - https://www.chessprogramming.org/Principal_Variation_Search
                 // The first move must be searched with the full alpha-beta window. If our move ordering is any good
                 // then we expect this to be the best move, and so we need to retrieve the exact score.


### PR DESCRIPTION
I am a big dumb idiot

The variable movesSearched is initialised to 0 and then immediately incremented after makeMove. Therefore the first move in every node is always searched with a null window...

Very embarrassing, on the other hand easiest 30 elo ever:

```
Score of Calvin DEV vs Calvin: 182 - 112 - 438  [0.548] 732
...      Calvin DEV playing White: 134 - 26 - 207  [0.647] 367
...      Calvin DEV playing Black: 48 - 86 - 231  [0.448] 365
...      White vs Black: 220 - 74 - 438  [0.600] 732
Elo difference: 33.3 +/- 15.9, LOS: 100.0 %, DrawRatio: 59.8 %
```