### PR TITLE
Simplify Searcher initialisation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-- [ ] MultiCut/Probcut
-- [ ] Singular Extension
-- [ ] Razoring
-- [ ] Improve Texel Tuner gradient descent algorithm
-- [ ] Datagen function for Texel/NNUE tuning
-- [ ] NNUE

--- a/src/main/java/com/kelseyde/calvin/engine/Engine.java
+++ b/src/main/java/com/kelseyde/calvin/engine/Engine.java
@@ -5,6 +5,7 @@ import com.kelseyde.calvin.board.Move;
 import com.kelseyde.calvin.endgame.Tablebase;
 import com.kelseyde.calvin.endgame.TablebaseException;
 import com.kelseyde.calvin.generation.MoveGeneration;
+import com.kelseyde.calvin.generation.MoveGenerator;
 import com.kelseyde.calvin.opening.OpeningBook;
 import com.kelseyde.calvin.search.Search;
 import com.kelseyde.calvin.search.SearchResult;
@@ -42,12 +43,12 @@ public class Engine {
     CompletableFuture<SearchResult> think;
     Board board;
 
-    public Engine(EngineConfig config, OpeningBook book, Tablebase tablebase, MoveGeneration moveGenerator, Search searcher) {
+    public Engine(EngineConfig config, OpeningBook book, Tablebase tablebase, Search searcher) {
         this.config = config;
         this.book = book;
         this.tablebase = tablebase;
-        this.moveGenerator = moveGenerator;
         this.searcher = searcher;
+        this.moveGenerator = new MoveGenerator();
     }
 
     public void newGame() {

--- a/src/main/java/com/kelseyde/calvin/engine/EngineInitializer.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineInitializer.java
@@ -4,15 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.endgame.LichessTablebase;
 import com.kelseyde.calvin.endgame.Tablebase;
-import com.kelseyde.calvin.evaluation.Evaluation;
 import com.kelseyde.calvin.evaluation.NNUE;
-import com.kelseyde.calvin.generation.MoveGeneration;
-import com.kelseyde.calvin.generation.MoveGenerator;
 import com.kelseyde.calvin.opening.OpeningBook;
 import com.kelseyde.calvin.search.ParallelSearcher;
 import com.kelseyde.calvin.search.Search;
-import com.kelseyde.calvin.search.moveordering.MoveOrderer;
-import com.kelseyde.calvin.search.moveordering.MoveOrdering;
 import com.kelseyde.calvin.tables.tt.TranspositionTable;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
@@ -21,7 +16,6 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -36,11 +30,8 @@ public class EngineInitializer {
         OpeningBook book = loadDefaultOpeningBook(config);
         Tablebase tablebase = loadDefaultTablebase(config);
         TranspositionTable transpositionTable = new TranspositionTable(config.getDefaultHashSizeMb());
-        Supplier<MoveGeneration> moveGenerator = MoveGenerator::new;
-        Supplier<MoveOrdering> moveOrderer = MoveOrderer::new;
-        Supplier<Evaluation> evaluator = NNUE::new;
-        Search searcher = new ParallelSearcher(config, moveGenerator, moveOrderer, evaluator, transpositionTable);
-        Engine engine = new Engine(config, book, tablebase, moveGenerator.get(), searcher);
+        Search searcher = new ParallelSearcher(config, transpositionTable);
+        Engine engine = new Engine(config, book, tablebase, searcher);
         engine.setPosition(new Board());
         return engine;
     }

--- a/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
@@ -3,9 +3,6 @@ package com.kelseyde.calvin.search;
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.board.Move;
 import com.kelseyde.calvin.engine.EngineConfig;
-import com.kelseyde.calvin.evaluation.Evaluation;
-import com.kelseyde.calvin.generation.MoveGeneration;
-import com.kelseyde.calvin.search.moveordering.MoveOrdering;
 import com.kelseyde.calvin.tables.tt.TranspositionTable;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
@@ -34,11 +31,8 @@ import java.util.stream.IntStream;
 public class ParallelSearcher implements Search {
 
     final EngineConfig config;
-    final Supplier<MoveGeneration> moveGeneratorSupplier;
-    final Supplier<MoveOrdering> moveOrdererSupplier;
-    final Supplier<Evaluation> evaluatorSupplier;
     final ThreadManager threadManager;
-    TranspositionTable transpositionTable;
+    TranspositionTable tt;
     int threadCount;
     int hashSize;
     Board board;
@@ -49,24 +43,14 @@ public class ParallelSearcher implements Search {
      * The suppliers are used to create the necessary components for each search thread.
      *
      * @param config the engine configuration
-     * @param moveGeneratorSupplier supplier for move generation
-     * @param moveOrdererSupplier supplier for move ordering
-     * @param evaluatorSupplier supplier for evaluation
-     * @param transpositionTable the shared transposition table
+     * @param tt the shared transposition table
      */
-    public ParallelSearcher(EngineConfig config,
-                            Supplier<MoveGeneration> moveGeneratorSupplier,
-                            Supplier<MoveOrdering> moveOrdererSupplier,
-                            Supplier<Evaluation> evaluatorSupplier,
-                            TranspositionTable transpositionTable) {
+    public ParallelSearcher(EngineConfig config, TranspositionTable tt) {
         this.config = config;
         this.hashSize = config.getDefaultHashSizeMb();
         this.threadCount = config.getDefaultThreadCount();
         this.threadManager = new ThreadManager();
-        this.transpositionTable = transpositionTable;
-        this.moveGeneratorSupplier = moveGeneratorSupplier;
-        this.moveOrdererSupplier = moveOrdererSupplier;
-        this.evaluatorSupplier = evaluatorSupplier;
+        this.tt = tt;
         this.searchers = initSearchers();
     }
 
@@ -87,7 +71,7 @@ public class ParallelSearcher implements Search {
                     .toList();
 
             SearchResult result = selectResult(threads).get();
-            transpositionTable.incrementGeneration();
+            tt.incrementGeneration();
             return result;
         } catch (Exception e) {
             System.out.println("info error " + e);
@@ -117,7 +101,7 @@ public class ParallelSearcher implements Search {
     @Override
     public void setHashSize(int hashSizeMb) {
         this.hashSize = hashSizeMb;
-        this.transpositionTable = new TranspositionTable(this.hashSize);
+        this.tt = new TranspositionTable(this.hashSize);
         this.searchers = initSearchers();
     }
 
@@ -177,10 +161,7 @@ public class ParallelSearcher implements Search {
      * @return the initialized searcher
      */
     private Searcher initSearcher() {
-        MoveGeneration moveGenerator = this.moveGeneratorSupplier.get();
-        MoveOrdering moveOrderer = this.moveOrdererSupplier.get();
-        Evaluation evaluator = this.evaluatorSupplier.get();
-        return new Searcher(config, threadManager, moveGenerator, moveOrderer, evaluator, transpositionTable);
+        return new Searcher(config, threadManager, tt);
     }
 
     /**
@@ -190,7 +171,7 @@ public class ParallelSearcher implements Search {
      */
     @Override
     public TranspositionTable getTranspositionTable() {
-        return transpositionTable;
+        return tt;
     }
 
     /**
@@ -198,7 +179,7 @@ public class ParallelSearcher implements Search {
      */
     @Override
     public void clearHistory() {
-        transpositionTable.clear();
+        tt.clear();
         searchers.forEach(Searcher::clearHistory);
     }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -5,9 +5,11 @@ import com.kelseyde.calvin.board.Move;
 import com.kelseyde.calvin.board.Piece;
 import com.kelseyde.calvin.engine.EngineConfig;
 import com.kelseyde.calvin.evaluation.Evaluation;
+import com.kelseyde.calvin.evaluation.NNUE;
 import com.kelseyde.calvin.evaluation.Score;
 import com.kelseyde.calvin.generation.MoveGeneration;
 import com.kelseyde.calvin.generation.MoveGeneration.MoveFilter;
+import com.kelseyde.calvin.generation.MoveGenerator;
 import com.kelseyde.calvin.search.moveordering.MoveOrderer;
 import com.kelseyde.calvin.search.moveordering.MoveOrdering;
 import com.kelseyde.calvin.search.moveordering.StaticExchangeEvaluator;
@@ -70,18 +72,13 @@ public class Searcher implements Search {
     int previousEval;
     int evalStability;
 
-    public Searcher(EngineConfig config,
-                    ThreadManager threadManager,
-                    MoveGeneration moveGenerator,
-                    MoveOrdering moveOrderer,
-                    Evaluation evaluator,
-                    TranspositionTable tt) {
+    public Searcher(EngineConfig config, ThreadManager threadManager, TranspositionTable tt) {
         this.config = config;
         this.threadManager = threadManager;
-        this.moveGenerator = moveGenerator;
-        this.moveOrderer = moveOrderer;
-        this.evaluator = evaluator;
         this.tt = tt;
+        this.moveGenerator = new MoveGenerator();
+        this.moveOrderer = new MoveOrderer();
+        this.evaluator = new NNUE();
         this.see = new StaticExchangeEvaluator();
     }
 

--- a/src/main/java/com/kelseyde/calvin/utils/train/TrainingDataScorer.java
+++ b/src/main/java/com/kelseyde/calvin/utils/train/TrainingDataScorer.java
@@ -185,12 +185,9 @@ public class TrainingDataScorer {
 
     private Searcher initSearcher() {
         EngineConfig config = EngineInitializer.loadDefaultConfig();
-        MoveGeneration moveGenerator = new MoveGenerator();
-        MoveOrdering moveOrderer = new MoveOrderer();
         TranspositionTable transpositionTable = new TranspositionTable(TT_SIZE);
         ThreadManager threadManager = new ThreadManager();
-        Evaluation evaluator = new NNUE();
-        return new Searcher(config, threadManager, moveGenerator, moveOrderer, evaluator, transpositionTable);
+        return new Searcher(config, threadManager, transpositionTable);
     }
 
 }

--- a/src/test/java/com/kelseyde/calvin/utils/TestUtils.java
+++ b/src/test/java/com/kelseyde/calvin/utils/TestUtils.java
@@ -41,12 +41,12 @@ public class TestUtils {
     public static final Evaluation EVALUATOR = new NNUE();
     public static final TranspositionTable TRANSPOSITION_TABLE = new TranspositionTable(PRD_CONFIG.getDefaultHashSizeMb());
     public static final ThreadManager THREAD_MANAGER = new ThreadManager();
-    public static final Searcher SEARCHER = new Searcher(TST_CONFIG, THREAD_MANAGER, MOVE_GENERATOR, MOVE_ORDERER, EVALUATOR, TRANSPOSITION_TABLE);
-    public static final Search PARALLEL_SEARCHER = new ParallelSearcher(PRD_CONFIG, MoveGenerator::new, MoveOrderer::new, NNUE::new, TRANSPOSITION_TABLE);
+    public static final Searcher SEARCHER = new Searcher(TST_CONFIG, THREAD_MANAGER, TRANSPOSITION_TABLE);
+    public static final Search PARALLEL_SEARCHER = new ParallelSearcher(PRD_CONFIG, TRANSPOSITION_TABLE);
     public static final String QUIET_POSITIONS_FILE = "src/test/resources/texel/quiet_positions.epd";
 
     public static Engine getEngine() {
-        return new Engine(PRD_CONFIG, OPENING_BOOK, TABLEBASE, new MoveGenerator(), new Searcher(PRD_CONFIG, new ThreadManager(), new MoveGenerator(), new MoveOrderer(), new NNUE(), new TranspositionTable(PRD_CONFIG.getDefaultHashSizeMb())));
+        return new Engine(PRD_CONFIG, OPENING_BOOK, TABLEBASE, new Searcher(PRD_CONFIG, new ThreadManager(), new TranspositionTable(PRD_CONFIG.getDefaultHashSizeMb())));
     }
 
     private static EngineConfig loadConfig(String configLocation) {


### PR DESCRIPTION
I have absolutely no explanation for this - I thought it would be a non-functional change. Must be too small sample size.

```
Score of Calvin DEV vs Calvin: 151 - 110 - 332  [0.535] 593
...      Calvin DEV playing White: 114 - 25 - 158  [0.650] 297
...      Calvin DEV playing Black: 37 - 85 - 174  [0.419] 296
...      White vs Black: 199 - 62 - 332  [0.616] 593
Elo difference: 24.1 +/- 18.5, LOS: 99.4 %, DrawRatio: 56.0 %
```