### PR TITLE
Compress TT entry

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
@@ -65,7 +65,7 @@ public class ParallelSearcher implements Search {
                     .toList();
 
             SearchResult result = selectResult(threads).get();
-            tt.incrementGeneration();
+            tt.incrementAge();
             return result;
         } catch (Exception e) {
             System.out.println("info error " + e);

--- a/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
@@ -21,7 +21,7 @@ public class TranspositionTable {
 
     private int tries;
     private int hits;
-    private int generation;
+    private int age;
 
     /**
      * Constructs a transposition table of the given size in megabytes.
@@ -31,7 +31,7 @@ public class TranspositionTable {
         entries = new HashEntry[tableSize];
         tries = 0;
         hits = 0;
-        generation = 0;
+        age = 0;
     }
 
     /**
@@ -48,7 +48,7 @@ public class TranspositionTable {
             HashEntry entry = entries[index + i];
             if (entry != null && entry.getZobristPart() == zobristPart) {
                 hits++;
-                entry.setGeneration(generation);
+                entry.setAge(age);
                 if (Score.isMateScore(entry.getScore())) {
                     int score = retrieveMateScore(entry.getScore(), ply);
                     return entry.withAdjustedScore(score);
@@ -117,7 +117,7 @@ public class TranspositionTable {
             }
 
             // Next, prefer to replace entries from earlier on in the game, since they are now less likely to be relevant.
-            if (generation > storedEntry.getGeneration()) {
+            if (age > storedEntry.getAge()) {
                 replacedByAge = true;
                 replacedIndex = i;
             }
@@ -132,15 +132,15 @@ public class TranspositionTable {
 
         // Store the new entry in the table at the chosen index.
         if (replacedIndex != -1) {
-            entries[replacedIndex] = HashEntry.of(key, score, staticEval, move, flag, depth, generation);
+            entries[replacedIndex] = HashEntry.of(key, score, staticEval, move, flag, depth, age);
         }
     }
 
     /**
-     * Increments the generation counter for the transposition table.
+     * Increments the age counter for the transposition table.
      */
-    public void incrementGeneration() {
-        generation++;
+    public void incrementAge() {
+        age++;
     }
 
     public void resize(int tableSizeMb) {
@@ -148,7 +148,7 @@ public class TranspositionTable {
         entries = new HashEntry[tableSize];
         tries = 0;
         hits = 0;
-        generation = 0;
+        age = 0;
     }
 
     /**
@@ -157,7 +157,7 @@ public class TranspositionTable {
     public void clear() {
         tries = 0;
         hits = 0;
-        generation = 0;
+        age = 0;
         entries = new HashEntry[tableSize];
     }
 

--- a/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
+++ b/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
@@ -74,7 +74,7 @@ public class TranspositionTableTest {
     public void testMaxDepth() {
         Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
         long zobristKey = board.getState().getKey();
-        int depth = 256;
+        int depth = 255;
         int score = -789;
         HashFlag flag = HashFlag.UPPER;
         Move move = null;
@@ -85,11 +85,23 @@ public class TranspositionTableTest {
     public void testPromotionFlag() {
         Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
         long zobristKey = board.getState().getKey();
-        int depth = 256;
+        int depth = 255;
         int score = -789;
         HashFlag flag = HashFlag.LOWER;
         Move move = Move.fromUCI("e7e8q");
         assertEntry(zobristKey, score, move, flag, depth);
+    }
+
+    @Test
+    public void testDepthClampedTo255() {
+        Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
+        long zobristKey = board.getState().getKey();
+        int depth = 256;
+        int score = -789;
+        HashFlag flag = HashFlag.LOWER;
+        Move move = Move.fromUCI("e7e8n");
+        HashEntry entry = HashEntry.of(zobristKey, score, 0,  move, flag, depth, 0);
+        Assertions.assertEquals(255, entry.getDepth());
     }
 
     @Test
@@ -125,7 +137,7 @@ public class TranspositionTableTest {
     }
 
     @Test
-    public void testSetGeneration() {
+    public void testSetAge() {
         Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
         long zobristKey = board.getState().getKey();
         int depth = 256;
@@ -136,8 +148,24 @@ public class TranspositionTableTest {
 
         Assertions.assertEquals(0, entry.getAge());
 
-        entry.setAge(127);
-        Assertions.assertEquals(127, entry.getAge());
+        entry.setAge(38);
+        Assertions.assertEquals(38, entry.getAge());
+    }
+
+    @Test
+    public void testAgeClampedTo63() {
+        Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
+        long zobristKey = board.getState().getKey();
+        int depth = 256;
+        int score = -789;
+        HashFlag flag = HashFlag.LOWER;
+        Move move = Move.fromUCI("e7e8n");
+        HashEntry entry = HashEntry.of(zobristKey, score, 0,  move, flag, depth, 0);
+
+        Assertions.assertEquals(0, entry.getAge());
+
+        entry.setAge(64);
+        Assertions.assertEquals(63, entry.getAge());
     }
 
     @Test
@@ -153,8 +181,8 @@ public class TranspositionTableTest {
 
         Assertions.assertEquals(10, entry.getStaticEval());
 
-        entry.setStaticEval(-4234);
-        Assertions.assertEquals(-4234, entry.getStaticEval());
+        entry.setStaticEval(-1);
+        Assertions.assertEquals(-1, entry.getStaticEval());
     }
 
     @Test
@@ -187,7 +215,7 @@ public class TranspositionTableTest {
         flag = HashFlag.UPPER;
         bestMove = Move.fromUCI("e2e4");
         eval = 28666;
-        depth = 256;
+        depth = 255;
         table.put(board.getState().getKey(), flag, depth, ply + 1, bestMove, 0,  eval);
 
         entry = table.get(board.getState().getKey(), ply);

--- a/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
+++ b/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
@@ -134,10 +134,10 @@ public class TranspositionTableTest {
         Move move = Move.fromUCI("e7e8n");
         HashEntry entry = HashEntry.of(zobristKey, score, 0,  move, flag, depth, 0);
 
-        Assertions.assertEquals(0, entry.getGeneration());
+        Assertions.assertEquals(0, entry.getAge());
 
-        entry.setGeneration(127);
-        Assertions.assertEquals(127, entry.getGeneration());
+        entry.setAge(127);
+        Assertions.assertEquals(127, entry.getAge());
     }
 
     @Test


### PR DESCRIPTION
Using two arrays of 64-bit longs instead of a full Java class with all it's padding + header shenanigans. 
```
Score of Calvin DEV vs Calvin: 627 - 531 - 1430  [0.519] 2588
...      Calvin DEV playing White: 495 - 112 - 687  [0.648] 1294
...      Calvin DEV playing Black: 132 - 419 - 743  [0.389] 1294
...      White vs Black: 914 - 244 - 1430  [0.629] 2588
Elo difference: 12.9 +/- 8.9, LOS: 99.8 %, DrawRatio: 55.3 %
```