### PR TITLE
Move history pruning before makemove

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -317,12 +317,32 @@ public class Searcher implements Search {
             // captures, promotions), then let's assume it will fail low and prune this node.
             if (!pvNode
                 && depth <= config.fpDepth.value
-                && staticEval + config.fpMargin.value + depth * config.fpScale.value <= alpha
-                && !inCheck
-                && !isCapture
-                && !isPromotion) {
+                && !inCheck && !isCapture && !isPromotion
+                && staticEval + config.fpMargin.value + depth * config.fpScale.value <= alpha) {
                 movePicker.setSkipQuiets(true);
                 continue;
+            }
+
+            // Late Move Reductions - https://www.chessprogramming.org/Late_Move_Reductions
+            // If the move is ordered late in the list, and isn't a 'noisy' move like a check, capture or promotion,
+            // let's save time by assuming it's less likely to be good, and reduce the search depth.
+            int reduction = 0;
+            if (depth >= config.lmrDepth.value
+                    && !isCapture && !isPromotion
+                    && movesSearched >= (pvNode ? config.lmrMinMoves.value + 1 : config.lmrMinMoves.value - 1)) {
+                reduction = config.lmrReductions[depth][movesSearched] - (pvNode ? 1 : 0);
+            }
+
+            // History pruning - https://www.chessprogramming.org/History_Leaf_Pruning
+            // Quiet moves which have a bad history score are pruned at the leaf nodes. This is a simple heuristic
+            // that assumes that moves which have historically been bad are likely to be bad in the current position.
+            if (!pvNode && !isCapture && !isPromotion
+                    && depth - reduction <= config.hpMaxDepth.value) {
+                int historyScore = this.history.getHistoryTable().get(move, board.isWhite());
+                if (historyScore < config.hpMargin.value * depth + config.hpOffset.value) {
+                    movePicker.setSkipQuiets(true);
+                    continue;
+                }
             }
 
             eval.makeMove(board, move);
@@ -333,6 +353,8 @@ public class Searcher implements Search {
             boolean isCheck = movegen.isCheck(board, board.isWhite());
             boolean isQuiet = !isCheck && !isCapture && !isPromotion;
             ss.setMove(ply, move, piece, captured, isCapture, isQuiet);
+
+            // Keep track of the quiet/noisy moves searched, used later to update search history.
             if (isQuiet) {
                 quietsSearched.add(new PlayedMove(move, piece, captured, false, true));
             } else if (isCapture) {
@@ -367,39 +389,6 @@ public class Searcher implements Search {
                 score = -search(depth - 1, ply + 1, -beta, -alpha);
             }
             else {
-                // Late Move Reductions - https://www.chessprogramming.org/Late_Move_Reductions
-                // If the move is ordered late in the list, and isn't a 'noisy' move like a check, capture or promotion,
-                // let's save time by assuming it's less likely to be good, and reduce the search depth.
-                int reduction = 0;
-                if (depth >= config.lmrDepth.value
-                    && movesSearched >= (pvNode ? config.lmrMinMoves.value + 1 : config.lmrMinMoves.value - 1)
-                    && isQuiet) {
-                    reduction = config.lmrReductions[depth][movesSearched];
-                    if (pvNode) {
-                        reduction--;
-                    }
-                    if (ttEntry != null && ttEntry.getMove() != null && isCapture) {
-                        reduction++;
-                    }
-                }
-
-                // History pruning - https://www.chessprogramming.org/History_Leaf_Pruning
-                // Quiet moves which have a bad history score are pruned at the leaf nodes. This is a simple heuristic
-                // that assumes that moves which have historically been bad are likely to be bad in the current position.
-                if (!pvNode
-                        && isQuiet
-                        && depth - reduction <= config.hpMaxDepth.value) {
-                    int historyScore = this.history.getHistoryTable().get(move, !board.isWhite());
-                    if (historyScore < config.hpMargin.value * depth + config.hpOffset.value) {
-                        eval.unmakeMove();
-                        board.unmakeMove();
-                        ss.unsetMove(ply);
-                        movePicker.setSkipQuiets(true);
-                        continue;
-                    }
-                }
-
-
                 // For all other moves apart from the principal variation, search with a null window (-alpha - 1, -alpha),
                 // to try and prove the move will fail low while saving the time spent on a full search.
                 score = -search(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);


### PR DESCRIPTION
Quick regression test, this is only the most fractional of speedups (less makemoves):

```
Score of Calvin DEV vs Calvin: 254 - 252 - 497  [0.501] 1003
...      Calvin DEV playing White: 190 - 60 - 252  [0.629] 502
...      Calvin DEV playing Black: 64 - 192 - 245  [0.372] 501
...      White vs Black: 382 - 124 - 497  [0.629] 1003
Elo difference: 0.7 +/- 15.3, LOS: 53.5 %, DrawRatio: 49.6 %
```