### PR TITLE
Use piece/to indexing for quiet history table

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
@@ -30,7 +30,7 @@ public class SearchHistory {
             killerTable.add(ply, bestMove.move());
             for (PlayedMove quiet : quiets) {
                 boolean good = bestMove.move().equals(quiet.move());
-                quietHistoryTable.update(quiet.move(), depth, white, good);
+                quietHistoryTable.update(quiet.move(), quiet.piece(), depth, white, good);
 
                 for (int prevPly : CONT_HIST_PLIES) {
                     Move prevMove = ss.getMove(ply - prevPly);

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -331,7 +331,7 @@ public class Searcher implements Search {
                 continue;
             }
 
-            int historyScore = this.history.getHistoryTable().get(move, board.isWhite());
+            int historyScore = this.history.getHistoryTable().get(move, piece, board.isWhite());
 
             // Late Move Reductions - https://www.chessprogramming.org/Late_Move_Reductions
             // If the move is ordered late in the list, and isn't a 'noisy' move like a check, capture or promotion,

--- a/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
@@ -163,7 +163,7 @@ public class MovePicker {
         int killerScore = killerIndex >= 0 ? MoveBonus.KILLER_OFFSET * (KillerTable.KILLERS_PER_PLY - killerIndex) : 0;
 
         // Get the history score for the move
-        int historyScore = history.getHistoryTable().get(move, white);
+        int historyScore = history.getHistoryTable().get(move, piece, white);
 
         // Get the continuation history score for the move
         Move prevMove = ss.getMove(ply - 1);

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -3,42 +3,32 @@ package com.kelseyde.calvin.tables.history;
 import com.kelseyde.calvin.board.Bits.Square;
 import com.kelseyde.calvin.board.Colour;
 import com.kelseyde.calvin.board.Move;
+import com.kelseyde.calvin.board.Piece;
 
 public class QuietHistoryTable extends AbstractHistoryTable {
 
     public static final int MAX_SCORE = 8192;
     private static final int MAX_BONUS = 1200;
 
-    int[][][] table = new int[2][Square.COUNT][Square.COUNT];
+    int[][][] table = new int[2][Piece.COUNT][Square.COUNT];
 
-    public void update(Move move, int depth, boolean white, boolean good) {
+    public void update(Move move, Piece piece, int depth, boolean white, boolean good) {
         int colourIndex = Colour.index(white);
-        int from = move.from();
-        int to = move.to();
-        int current = table[colourIndex][from][to];
+        int current = table[colourIndex][piece.index()][move.to()];
         int bonus = bonus(depth);
         if (!good) bonus = -bonus;
         int update = gravity(current, bonus);
-        table[colourIndex][from][to] = update;
+        table[colourIndex][piece.index()][move.to()] = update;
     }
 
-    public int get(Move historyMove, boolean white) {
+    public int get(Move move, Piece piece, boolean white) {
         int colourIndex = Colour.index(white);
-        int from = historyMove.from();
-        int to = historyMove.to();
-        return table[colourIndex][from][to];
-    }
-
-    public void set(Move historyMove, boolean white, int update) {
-        int colourIndex = Colour.index(white);
-        int from = historyMove.from();
-        int to = historyMove.to();
-        table[colourIndex][from][to] = update;
+        return table[colourIndex][piece.index()][move.to()];
     }
 
     public void ageScores(boolean white) {
         int colourIndex = Colour.index(white);
-        for (int from = 0; from < Square.COUNT; from++) {
+        for (int from = 0; from < Piece.COUNT; from++) {
             for (int to = 0; to < Square.COUNT; to++) {
                 table[colourIndex][from][to] /= 2;
             }
@@ -46,7 +36,7 @@ public class QuietHistoryTable extends AbstractHistoryTable {
     }
 
     public void clear() {
-        table = new int[2][Square.COUNT][Square.COUNT];
+        table = new int[2][Piece.COUNT][Square.COUNT];
     }
 
     @Override


### PR DESCRIPTION
Merging early because most other engines do it, it uses up fractionally less memory, and it brings the quiet history table in line with the other tables.

```
Score of Calvin DEV vs Calvin: 265 - 250 - 522  [0.507] 1037
...      Calvin DEV playing White: 207 - 54 - 257  [0.648] 518
...      Calvin DEV playing Black: 58 - 196 - 265  [0.367] 519
...      White vs Black: 403 - 112 - 522  [0.640] 1037
Elo difference: 5.0 +/- 14.9, LOS: 74.6 %, DrawRatio: 50.3 %
```