### PR TITLE
TT non cutoff extension

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -55,6 +55,7 @@ public class EngineConfig {
     public final Tunable hpMaxDepth           = new Tunable("HpMaxDepth", 3, 0, 10, 1);
     public final Tunable hpMargin             = new Tunable("HpMargin", -2197, -4000, -100, 50);
     public final Tunable hpOffset             = new Tunable("HpOffset", -1039, -3000, 0, 50);
+    public final Tunable ttExtensionDepth     = new Tunable("TtExtDepth", 6, 0, 12, 1);
     public final Tunable quietHistBonusMax    = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     public final Tunable quietHistBonusScale  = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
     public final Tunable quietHistMalusMax    = new Tunable("QuietHistMalusMax", 1200, 100, 2000, 100);

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -191,11 +191,14 @@ public class Searcher implements Search {
         //  c) the score is either exact, or outside the bounds of the current alpha-beta window.
         final HashEntry ttEntry = tt.get(board.key(), ply);
         final boolean ttHit = ttEntry != null;
-        if (!pvNode
-                && ttHit
-                && isSufficientDepth(ttEntry, depth)
-                && isWithinBounds(ttEntry, alpha, beta)) {
-            return ttEntry.score();
+
+        if (!pvNode && ttHit && isSufficientDepth(ttEntry, depth)) {
+            if (isWithinBounds(ttEntry, alpha, beta)) {
+                return ttEntry.score();
+            }
+            else if (depth <= config.ttExtensionDepth.value) {
+                depth++;
+            }
         }
 
         Move ttMove = null;


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 1346 - 1211 - 2806  [0.513] 5363
...      Calvin DEV playing White: 1083 - 235 - 1364  [0.658] 2682
...      Calvin DEV playing Black: 263 - 976 - 1442  [0.367] 2681
...      White vs Black: 2059 - 498 - 2806  [0.646] 5363
Elo difference: 8.7 +/- 6.4, LOS: 99.6 %, DrawRatio: 52.3 %
SPRT: llr 2.91 (100.8%), lbound -2.25, ubound 2.89 - H1 was accepted
```