### PR TITLE
Capthist late move reductions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
@@ -101,7 +101,7 @@ public class SearchHistory {
         return killerTable;
     }
 
-    public QuietHistoryTable getHistoryTable() {
+    public QuietHistoryTable getQuietHistoryTable() {
         return quietHistoryTable;
     }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -337,7 +337,9 @@ public class Searcher implements Search {
                 continue;
             }
 
-            final int historyScore = this.history.getHistoryTable().get(move, piece, board.isWhite());
+            final int historyScore = isCapture ?
+                    this.history.getCaptureHistoryTable().get(piece, move.to(), captured, board.isWhite()) :
+                    this.history.getQuietHistoryTable().get(move, piece, board.isWhite());
 
             // Late Move Reductions - https://www.chessprogramming.org/Late_Move_Reductions
             // If the move is ordered late in the list, and isn't a 'noisy' move like a check, capture or promotion,
@@ -399,6 +401,7 @@ public class Searcher implements Search {
             }
 
             int score;
+
             if (isDraw()) {
                 // No need to search if the position is a legal draw (3-fold, insufficient material, or 50-move rule).
                 score = Score.DRAW;

--- a/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
@@ -163,7 +163,7 @@ public class MovePicker {
         int killerScore = killerIndex >= 0 ? MoveBonus.KILLER_OFFSET * (KillerTable.KILLERS_PER_PLY - killerIndex) : 0;
 
         // Get the history score for the move
-        int historyScore = history.getHistoryTable().get(move, piece, white);
+        int historyScore = history.getQuietHistoryTable().get(move, piece, white);
 
         // Get the continuation history score for the move
         Move prevMove = ss.getMove(ply - 1);


### PR DESCRIPTION
Previously was using quiet history score for capture LMR, which doesn't make any sense. 
```
Score of Calvin DEV vs Calvin: 2165 - 2125 - 4283  [0.502] 8573
...      Calvin DEV playing White: 1717 - 410 - 2160  [0.652] 4287
...      Calvin DEV playing Black: 448 - 1715 - 2123  [0.352] 4286
...      White vs Black: 3432 - 858 - 4283  [0.650] 8573
Elo difference: 1.6 +/- 5.2, LOS: 72.9 %, DrawRatio: 50.0 %
```