### PR TITLE
NMP eval-based reduction

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -83,13 +83,14 @@ public class EngineConfig {
 
     public Set<Tunable> getTunables() {
         return Set.of(
-                aspMargin, aspFailMargin, aspMaxReduction, nmpDepth, fpDepth, rfpDepth, lmrDepth, lmrBase, lmrDivisor,
-                lmrCapBase, lmrCapDivisor, lmrMinMoves, lmrMinPvMoves, lmpDepth, lmpMultiplier, iirDepth, nmpMargin,
-                nmpImpMargin, nmpBase, nmpDivisor, dpMargin, qsFpMargin, qsSeeEqualDepth, fpMargin, fpScale, rfpMargin,
-                rfpImpMargin, razorDepth, razorMargin, hpMaxDepth, hpMargin, hpOffset, quietHistBonusMax, quietHistBonusScale,
-                quietHistMalusMax, quietHistMalusScale, quietHistMaxScore, captHistBonusMax, captHistBonusScale,
-                captHistMalusMax, captHistMalusScale, captHistMaxScore, contHistBonusMax, contHistBonusScale,
-                contHistMalusMax, contHistMalusScale, contHistMaxScore, nodeTmMinDepth, nodeTmBase, nodeTmScale
+                aspMargin, aspFailMargin, aspMaxReduction, nmpDepth, nmpEvalScale, nmpEvalMaxReduction, fpDepth,
+                rfpDepth, lmrDepth, lmrBase, lmrDivisor, lmrCapBase, lmrCapDivisor, lmrMinMoves, lmrMinPvMoves,
+                lmpDepth, lmpMultiplier, iirDepth, nmpMargin, nmpImpMargin, nmpBase, nmpDivisor, dpMargin, qsFpMargin,
+                qsSeeEqualDepth, fpMargin, fpScale, rfpMargin, rfpImpMargin, razorDepth, razorMargin, hpMaxDepth,
+                hpMargin, hpOffset, quietHistBonusMax, quietHistBonusScale, quietHistMalusMax, quietHistMalusScale,
+                quietHistMaxScore, captHistBonusMax, captHistBonusScale, captHistMalusMax, captHistMalusScale,
+                captHistMaxScore, contHistBonusMax, contHistBonusScale, contHistMalusMax, contHistMalusScale,
+                contHistMaxScore, nodeTmMinDepth, nodeTmBase, nodeTmScale
         );
     }
 

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -33,6 +33,8 @@ public class EngineConfig {
     public final Tunable nmpImpMargin         = new Tunable("NmpImpMargin", 52, 0, 250, 10);
     public final Tunable nmpBase              = new Tunable("NmpBase", 3, 0, 6, 1);
     public final Tunable nmpDivisor           = new Tunable("NmpDivisor", 2, 1, 4, 1);
+    public final Tunable nmpEvalScale         = new Tunable("NmpEvalScale", 210, 0, 400, 25);
+    public final Tunable nmpEvalMaxReduction  = new Tunable("NmpEvalMaxReduction", 4, 2, 5, 1);
     public final Tunable fpDepth              = new Tunable("FpDepth", 5, 0, 8, 1);
     public final Tunable fpMargin             = new Tunable("FpMargin", 259, 0, 500, 10);
     public final Tunable fpScale              = new Tunable("FpScale", 68, 0, 100, 5);

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -294,9 +294,13 @@ public class Searcher implements Search {
 
                 final int base = config.nmpBase.value;
                 final int divisor = config.nmpDivisor.value;
-                final int r = base + depth / divisor;
-                // TODO improving reduction
-                // TODO eval-based reduction
+                final int evalScale = config.nmpEvalScale.value;
+                final int evalMaxReduction = config.nmpEvalMaxReduction.value;
+                final int evalReduction = Math.min((staticEval - beta) / evalScale, evalMaxReduction);
+                final int r = base
+                        + depth / divisor
+                        + evalReduction;
+
                 final int score = -search(depth - r, ply + 1, -beta, -beta + 1);
 
                 board.unmakeNullMove();


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 1763 - 1614 - 3435  [0.511] 6812
...      Calvin DEV playing White: 1352 - 383 - 1671  [0.642] 3406
...      Calvin DEV playing Black: 411 - 1231 - 1764  [0.380] 3406
...      White vs Black: 2583 - 794 - 3435  [0.631] 6812
Elo difference: 7.6 +/- 5.8, LOS: 99.5 %, DrawRatio: 50.4 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```