### PR TITLE
Treat en passants as capture moves in search

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -573,7 +573,7 @@ public class Searcher implements Search {
                 // Delta Pruning - https://www.chessprogramming.org/Delta_Pruning
                 // If the captured piece + a margin still has no potential of raising alpha, let's assume this position
                 // is bad for us no matter what we do, and not bother searching any further
-                final Piece captured = move.isEnPassant() ? Piece.PAWN : board.pieceAt(move.to());
+                final Piece captured = scoredMove.captured();
                 if (captured != null
                         && !move.isPromotion()
                         && (staticEval + captured.value() + config.dpMargin.value < alpha)) {

--- a/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
@@ -97,7 +97,7 @@ public class MovePicker {
     protected ScoredMove pickTTMove() {
         stage = Stage.GEN_NOISY;
         final Piece piece = board.pieceAt(ttMove.from());
-        final Piece captured = board.pieceAt(ttMove.to());
+        final Piece captured = ttMove.isEnPassant() ? Piece.PAWN : board.pieceAt(ttMove.to());
         return new ScoredMove(ttMove, piece, captured, MoveType.TT_MOVE.bonus, 0, MoveType.TT_MOVE);
     }
 
@@ -124,7 +124,7 @@ public class MovePicker {
         final int to = move.to();
 
         final Piece piece = board.pieceAt(from);
-        final Piece captured = board.pieceAt(to);
+        final Piece captured = move.isEnPassant() ? Piece.PAWN : board.pieceAt(to);
         final boolean isCapture = captured != null;
         boolean isNoisy = isCapture || move.isPromotion();
 


### PR DESCRIPTION
Probably doesn't make much difference, but I'm merging as it's just incorrect to treat them as quiets.

```
Score of Calvin DEV vs Calvin: 355 - 353 - 502  [0.501] 1210
...      Calvin DEV playing White: 242 - 106 - 257  [0.612] 605
...      Calvin DEV playing Black: 113 - 247 - 245  [0.389] 605
...      White vs Black: 489 - 219 - 502  [0.612] 1210
Elo difference: 0.6 +/- 15.0, LOS: 53.0 %, DrawRatio: 41.5 %
```