### PR TITLE
RFP quiet reductions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -275,7 +275,7 @@ public class Searcher implements Search {
                 int baseMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value);
                 int blend = depth * 4;
 
-                // At the stricter margin we prune the entire node; at the softer margin we reduce search depth.
+                // At the stricter margin we prune the entire node; at the softer margin we reduce quiet moves only.
                 int pruneMargin = baseMargin - blend;
                 int reduceMargin = baseMargin + blend;
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -271,10 +271,12 @@ public class Searcher implements Search {
             // is a cut-node and will fail-high, and not search any further.
             if (depth <= config.rfpDepth.value
                 && !Score.isMateScore(alpha)) {
+
                 int blend = depth * 4;
                 int baseMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value);
                 int pruneMargin = baseMargin - blend;
                 int reduceMargin = baseMargin + blend;
+
                 if (staticEval - pruneMargin >= beta) {
                     return (staticEval + beta) / 2;
                 }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -272,8 +272,10 @@ public class Searcher implements Search {
             if (depth <= config.rfpDepth.value
                 && !Score.isMateScore(alpha)) {
 
-                int blend = depth * 4;
                 int baseMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value);
+                int blend = depth * 4;
+
+                // At the stricter margin we prune the entire node; at the softer margin we reduce search depth.
                 int pruneMargin = baseMargin - blend;
                 int reduceMargin = baseMargin + blend;
 


### PR DESCRIPTION
Tighten RFP pruning margin and add a softer margin where, instead of pruning, all quiet moves are reduced.

STC:
```
Score of Calvin DEV vs Calvin: 1397 - 1244 - 1748  [0.517] 4389
...      Calvin DEV playing White: 972 - 360 - 863  [0.639] 2195
...      Calvin DEV playing Black: 425 - 884 - 885  [0.395] 2194
...      White vs Black: 1856 - 785 - 1748  [0.622] 4389
Elo difference: 12.1 +/- 8.0, LOS: 99.9 %, DrawRatio: 39.8 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```