### PR TITLE
Variable-depth reverse futility reductions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -266,16 +266,14 @@ public class Searcher implements Search {
         // can employ to prune the node and its entire subtree, without searching any moves.
         if (!pvNode && !inCheck) {
 
-// Reverse Futility Pruning - https://www.chessprogramming.org/Reverse_Futility_Pruning
-// If the static evaluation + some significant margin is still above beta, then let's assume this position
-// is a cut-node and will fail-high, and not search any further.
+            // Reverse Futility Pruning - https://www.chessprogramming.org/Reverse_Futility_Pruning
+            // If the static evaluation + some significant margin is still above beta, then let's assume this position
+            // is a cut-node and will fail-high, and not search any further.
             if (depth <= config.rfpDepth.value && !Score.isMateScore(alpha)) {
 
-                // Calculate base margin with additional blend factor to create softer pruning
                 int baseMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value);
                 int blend = depth * 4;
 
-                // Define pruneMargin and reduceMargin
                 int pruneMargin = baseMargin - blend;
                 int reduceMargin = baseMargin + blend;
 
@@ -288,9 +286,6 @@ public class Searcher implements Search {
                 else if (staticEval - reduceMargin >= beta) {
                     // Calculate distance from beta in units of 'blend' to scale reduction dynamically
                     int delta = (staticEval - beta) - reduceMargin;
-
-                    // Scale quietReduction based on how far the eval is above beta, capped between 1 and 3
-                    // The idea is to reduce more if staticEval is much greater than beta
                     quietReduction = 1 + Math.min(2, delta / blend);
                 }
             }


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 1227 - 1073 - 1308  [0.521] 3608
...      Calvin DEV playing White: 828 - 326 - 651  [0.639] 1805
...      Calvin DEV playing Black: 399 - 747 - 657  [0.403] 1803
...      White vs Black: 1575 - 725 - 1308  [0.618] 3608
Elo difference: 14.8 +/- 9.0, LOS: 99.9 %, DrawRatio: 36.3 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```