### PR TITLE
Variable-depth futility reductions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -373,11 +373,11 @@ public class Searcher implements Search {
                     continue;
                 }
                 else if (staticEval + reduceMargin <= alpha) {
-                    // Calculate how far staticEval is from alpha, and determine dynamic reduction
-                    int distFromAlpha = (alpha - staticEval) - pruneMargin;
+                    // Calculate distance from alpha to scale reduction dynamically
+                    int delta = (alpha - staticEval) - pruneMargin;
 
                     int maxReduction = config.fpDepth.value;
-                    quietReduction = 1 + Math.min(distFromAlpha / (reduceMargin - pruneMargin), maxReduction - 1);
+                    quietReduction = 1 + Math.min(delta / (reduceMargin - pruneMargin), maxReduction - 1);
                 }
             }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -361,8 +361,8 @@ public class Searcher implements Search {
             // If the static evaluation + some margin is still < alpha, and the current move is not interesting (checks,
             // captures, promotions), then let's assume it will fail low and prune this node.
             if (!pvNode
-                && depth <= config.fpDepth.value
-                && !inCheck && !isCapture && !isPromotion) {
+                    && depth <= config.fpDepth.value
+                    && !inCheck && !isCapture && !isPromotion) {
 
                 // Two margins - a strict margin where we fully prune the move, and a softer margin where we reduce depth.
                 int pruneMargin = config.fpMargin.value + depth * config.fpScale.value;
@@ -373,7 +373,11 @@ public class Searcher implements Search {
                     continue;
                 }
                 else if (staticEval + reduceMargin <= alpha) {
-                    quietReduction = 1;
+                    // Calculate how far staticEval is from alpha, and determine dynamic reduction
+                    int distFromAlpha = (alpha - staticEval) - pruneMargin;
+
+                    int maxReduction = config.fpDepth.value;
+                    quietReduction = 1 + Math.min(distFromAlpha / (reduceMargin - pruneMargin), maxReduction - 1);
                 }
             }
 


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 3911 - 3699 - 5086  [0.508] 12696
...      Calvin DEV playing White: 2755 - 1123 - 2471  [0.629] 6349
...      Calvin DEV playing Black: 1156 - 2576 - 2615  [0.388] 6347
...      White vs Black: 5331 - 2279 - 5086  [0.620] 12696
Elo difference: 5.8 +/- 4.7, LOS: 99.2 %, DrawRatio: 40.1 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```