### PR TITLE
Stop extending late moves with good history score...

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -406,6 +406,7 @@ public class Searcher implements Search {
 
                 // Reduce moves with a bad history score more aggressively, and reduce less if the history score is good.
                 reduction -= 2 * historyScore / config.quietHistMaxScore.value;
+                reduction = Math.max(0, reduction);
             }
 
             // History pruning - https://www.chessprogramming.org/History_Leaf_Pruning


### PR DESCRIPTION
Woops

```
Score of Calvin DEV vs Calvin: 625 - 487 - 670  [0.539] 1782
...      Calvin DEV playing White: 435 - 141 - 316  [0.665] 892
...      Calvin DEV playing Black: 190 - 346 - 354  [0.412] 890
...      White vs Black: 781 - 331 - 670  [0.626] 1782
Elo difference: 27.0 +/- 12.7, LOS: 100.0 %, DrawRatio: 37.6 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```