### PR TITLE
Reset ply counter to 0 after applying moves from UCI

### DIFF
--- a/src/main/java/com/kelseyde/calvin/board/Board.java
+++ b/src/main/java/com/kelseyde/calvin/board/Board.java
@@ -606,6 +606,12 @@ public class Board {
                 (getKnights(false) != 0 || getBishops(false) != 0 || getRooks(false) != 0 || getQueens(false) != 0);
     }
 
+    public void resetCounter() {
+        ply = 0;
+        moves = new Move[Search.MAX_DEPTH];
+        states = new BoardState[Search.MAX_DEPTH];
+    }
+
     public static Board from(String fen) {
         return FEN.toBoard(fen);
     }

--- a/src/main/java/com/kelseyde/calvin/engine/Engine.java
+++ b/src/main/java/com/kelseyde/calvin/engine/Engine.java
@@ -66,6 +66,7 @@ public class Engine {
             Move legalMove = move(move);
             board.makeMove(legalMove);
         }
+        board.resetCounter();
         searcher.setPosition(board);
     }
 


### PR DESCRIPTION
As pointed out by Stormphrax author after some crashes in CCRL tests.

Merging early, since this was clearly incorrect behaviour and the benefits will probably only be noticed at LTC. 

```
Score of Calvin DEV vs Calvin: 987 - 918 - 2208  [0.508] 4113
...      Calvin DEV playing White: 698 - 261 - 1098  [0.606] 2057
...      Calvin DEV playing Black: 289 - 657 - 1110  [0.411] 2056
...      White vs Black: 1355 - 550 - 2208  [0.598] 4113
Elo difference: 5.8 +/- 7.2, LOS: 94.3 %, DrawRatio: 53.7 %
```