### PR TITLE
Disable pretty print for tournament runners

### DIFF
--- a/src/main/java/com/kelseyde/calvin/uci/UCI.java
+++ b/src/main/java/com/kelseyde/calvin/uci/UCI.java
@@ -80,6 +80,10 @@ public class UCI {
         write("option name Pretty type check default false");
         ENGINE.getConfig().getTunables().forEach(t -> write(t.toUCI()));
         write("uciok");
+
+        // Typically 'uci' is only sent by tournament runners, not humans.
+        // Therefore, let's disable pretty print when receiving a 'uci' command.
+        Options.pretty = false;
     }
 
     public static void handleBench(UCICommand command) {


### PR DESCRIPTION
Non-functional, quick regresstion test:

```
Score of Calvin DEV vs Calvin: 114 - 119 - 404  [0.496] 637
...      Calvin DEV playing White: 97 - 29 - 193  [0.607] 319
...      Calvin DEV playing Black: 17 - 90 - 211  [0.385] 318
...      White vs Black: 187 - 46 - 404  [0.611] 637
Elo difference: -2.7 +/- 16.3, LOS: 37.2 %, DrawRatio: 63.4 %
```