### PR TITLE
Overwrite TT entries where depth >= ttDepth - 4

### DIFF
--- a/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
@@ -121,7 +121,7 @@ public class TranspositionTable {
             // Then, if the stored entry matches the zobrist key and the depth is >= the stored depth, replace it.
             // If the depth is < the store depth, don't replace it and exit (although this should never happen).
             if (HashEntry.Key.getZobristPart(storedKey) == HashEntry.Key.getZobristPart(key)) {
-                if (depth >= storedDepth) {
+                if (depth >= storedDepth - 4) {
                     // If the stored entry has a recorded best move but the new entry does not, use the stored one.
                     Move storedMove = HashEntry.Value.getMove(storedValue);
                     if (move == null && storedMove != null) {

--- a/src/main/resources/TODO.md
+++ b/src/main/resources/TODO.md
@@ -39,10 +39,10 @@
 - [ ] Major corrhist ( tried )
 - [ ] Minor corrhist ( tried )
 - [ ] Contcorrhist
-- [ ] Threat corrhist ( tried, failed SPRT )
+- [ ] Threat corrhist ( tried )
 - [ ] Countermove corrhist?
 - [ ] Follow-up move corrhist?
-- [ ] TT-move corrhist? ( tried, failed SPRT )
+- [ ] TT-move corrhist? ( tried )
 - [x] TT score eval correction
 - [ ] LMP table
 - [ ] Reduce killers less

--- a/src/main/resources/TODO.md
+++ b/src/main/resources/TODO.md
@@ -93,6 +93,7 @@
 ### Transposition Table
 
 - [x] Always store eval in TT (should be 5-ish elo?)
+- [ ] Tune TT depth cut-off
 - [ ] PV node flag in TT
 - [ ] 16-bits zobrist in TT? (SF does it)
 - [ ] Fully compress all fields to minimum size


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 544 - 431 - 1012  [0.528] 1987
...      Calvin DEV playing White: 448 - 72 - 474  [0.689] 994
...      Calvin DEV playing Black: 96 - 359 - 538  [0.368] 993
...      White vs Black: 807 - 168 - 1012  [0.661] 1987
Elo difference: 19.8 +/- 10.7, LOS: 100.0 %, DrawRatio: 50.9 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```