### PR TITLE
Always overwrite TT entry if we have an exact score

### DIFF
--- a/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
@@ -109,6 +109,12 @@ public class TranspositionTable {
                 break;
             }
 
+            // Second, always prefer an exact score
+            if (flag == HashFlag.EXACT) {
+                replacedIndex = i;
+                break;
+            }
+
             long storedValue = values[i];
 
             HashFlag storedFlag = HashEntry.Value.getFlag(storedValue);


### PR DESCRIPTION
Story so far:
```
Score of Calvin DEV vs Calvin: 567 - 544 - 1252  [0.505] 2363
...      Calvin DEV playing White: 469 - 92 - 621  [0.659] 1182
...      Calvin DEV playing Black: 98 - 452 - 631  [0.350] 1181
...      White vs Black: 921 - 190 - 1252  [0.655] 2363
Elo difference: 3.4 +/- 9.6, LOS: 75.5 %, DrawRatio: 53.0 %
```