### PR TITLE
PVS SEE noisy pruning

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -395,11 +395,13 @@ public class Searcher implements Search {
             // Prune moves that lose material beyond a certain threshold, once all the pieces have been exchanged.
             if (!pvNode
                 && depth <= config.seeMaxDepth.value
-                && scoredMove.isQuiet()
+                && movesSearched > 1
+                && (scoredMove.isQuiet() || (scoredMove.isBadNoisy() && isCapture))
                 && !Score.isMateScore(bestScore)) {
 
-                final int margin = config.seeQuietMargin.value;
-                int threshold = margin * depth;
+                int threshold = scoredMove.isQuiet() ?
+                        config.seeQuietMargin.value * depth :
+                        config.seeNoisyMargin.value * depth * depth;
                 if (!SEE.see(board, move, threshold)) {
                     continue;
                 }


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 1251 - 1108 - 1841  [0.517] 4200
...      Calvin DEV playing White: 950 - 264 - 886  [0.663] 2100
...      Calvin DEV playing Black: 301 - 844 - 955  [0.371] 2100
...      White vs Black: 1794 - 565 - 1841  [0.646] 4200
Elo difference: 11.8 +/- 7.9, LOS: 99.8 %, DrawRatio: 43.8 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```