### PR TITLE
Use negative pawn threshold for SEE move ordering

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
@@ -235,7 +235,8 @@ public class MovePicker {
         }
 
         // Separate good and bad noisies based on the MVV-LVA ('most valuable victim, least valuable attacker') heuristic
-        final MoveType type = SEE.see(board, move, 0) ? MoveType.GOOD_NOISY : MoveType.BAD_NOISY;
+        final MoveType type = SEE.see(board, move, -SEE.value(Piece.PAWN)) ?
+                MoveType.GOOD_NOISY : MoveType.BAD_NOISY;
 
         final int materialDelta = SEE.value(captured) - SEE.value(piece);
 


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 4058 - 3844 - 6604  [0.507] 14506
...      Calvin DEV playing White: 3132 - 847 - 3274  [0.658] 7253
...      Calvin DEV playing Black: 926 - 2997 - 3330  [0.357] 7253
...      White vs Black: 6129 - 1773 - 6604  [0.650] 14506
Elo difference: 5.1 +/- 4.2, LOS: 99.2 %, DrawRatio: 45.5 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```