### PR TITLE
Stop doing QS SEE pruning when in check

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -677,7 +677,7 @@ public class Searcher implements Search {
             // Evaluate the possible captures + recaptures on the target square, in order to filter out losing capture
             // chains, such as capturing with the queen a pawn defended by another pawn.
             final int seeThreshold = depth <= config.qsSeeEqualDepth.value ? 0 : 1;
-            if (!SEE.see(board, move, seeThreshold)) {
+            if (!inCheck && !SEE.see(board, move, seeThreshold)) {
                 continue;
             }
 


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 1749 - 1587 - 2160  [0.515] 5496
...      Calvin DEV playing White: 1233 - 451 - 1065  [0.642] 2749
...      Calvin DEV playing Black: 516 - 1136 - 1095  [0.387] 2747
...      White vs Black: 2369 - 967 - 2160  [0.628] 5496
Elo difference: 10.2 +/- 7.1, LOS: 99.7 %, DrawRatio: 39.3 %
SPRT: llr 2.91 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```