### PR TITLE
Stop excluding killers/promotions from history bonuses

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -464,8 +464,8 @@ public class Searcher implements Search {
             final int nodesBefore = td.nodes;
             td.nodes++;
 
-            playedMove.quiet = scoredMove.isQuiet();
-            playedMove.capture = scoredMove.captured() != null;
+            playedMove.quiet = captured == null;
+            playedMove.capture = captured != null;
 
             if (scoredMove.isQuiet() || scoredMove.isBadNoisy()) {
                 reduction += futilityReduction;

--- a/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
@@ -246,8 +246,7 @@ public class MovePicker {
         final int threshold = -score / 4 + config.seeNoisyOffset.value;
 
         // Separate good and bad noisies based on the material won or lost once all pieces are swapped off.
-        final MoveType type = SEE.see(board, move, threshold) ?
-                MoveType.GOOD_NOISY : MoveType.BAD_NOISY;
+        final MoveType type = SEE.see(board, move, threshold) ? MoveType.GOOD_NOISY : MoveType.BAD_NOISY;
 
         return new ScoredMove(move, piece, captured, score, historyScore, type);
     }


### PR DESCRIPTION
```
Score of Calvin DEV vs Calvin: 2015 - 1851 - 2867  [0.512] 6733
...      Calvin DEV playing White: 1499 - 457 - 1412  [0.655] 3368
...      Calvin DEV playing Black: 516 - 1394 - 1455  [0.370] 3365
...      White vs Black: 2893 - 973 - 2867  [0.643] 6733
Elo difference: 8.5 +/- 6.3, LOS: 99.6 %, DrawRatio: 42.6 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```