### PR TITLE
Simplify Q-search MovePicker logic

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MovePicker.java
@@ -185,9 +185,9 @@ public class MovePicker {
             int goodIndex = 0;
             for (Move move : stagedMoves) {
                 ScoredMove scoredMove = scoreMove(board, move, ttMove, ply);
-                // In quiescence search, only consider good noisies or quiet checks,
+                // In q-search, only consider good noisies
                 // unless we are in check, in which case consider all moves.
-                if (inCheck || (scoredMove.isGoodNoisy() || scoredMove.captured() == null)) {
+                if (scoredMove.isGoodNoisy() || inCheck) {
                     goodNoisies[goodIndex++] = scoredMove;
                 }
             }


### PR DESCRIPTION
Non-functional as captured is never null in Q-search.

```
Score of Calvin DEV vs Calvin: 2721 - 2732 - 4606  [0.499] 10059
...      Calvin DEV playing White: 2066 - 628 - 2335  [0.643] 5029
...      Calvin DEV playing Black: 655 - 2104 - 2271  [0.356] 5030
...      White vs Black: 4170 - 1283 - 4606  [0.644] 10059
Elo difference: -0.4 +/- 5.0, LOS: 44.1 %, DrawRatio: 45.8 %
```