### PR TITLE
Remove history ageing

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
@@ -139,8 +139,6 @@ public class SearchHistory {
     public void reset() {
         bestMoveStability = 0;
         bestScoreStability = 0;
-        quietHistoryTable.ageScores(true);
-        quietHistoryTable.ageScores(false);
     }
 
     public void clear() {

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -31,15 +31,6 @@ public class QuietHistoryTable extends AbstractHistoryTable {
         return table[colourIndex][piece.index()][move.to()];
     }
 
-    public void ageScores(boolean white) {
-        int colourIndex = Colour.index(white);
-        for (int from = 0; from < Piece.COUNT; from++) {
-            for (int to = 0; to < Square.COUNT; to++) {
-                table[colourIndex][from][to] /= 2;
-            }
-        }
-    }
-
     public void clear() {
         table = new int[2][Piece.COUNT][Square.COUNT];
     }


### PR DESCRIPTION
Merging early as I should have run a non-reg - history ageing is pointless combined with the gravity formula

```
Score of Calvin DEV vs Calvin: 4179 - 4079 - 6742  [0.503] 15000
...      Calvin DEV playing White: 3153 - 960 - 3388  [0.646] 7501
...      Calvin DEV playing Black: 1026 - 3119 - 3354  [0.360] 7499
...      White vs Black: 6272 - 1986 - 6742  [0.643] 15000
Elo difference: 2.3 +/- 4.1, LOS: 86.4 %, DrawRatio: 44.9 %
```