### PR TITLE
Aspiration window tweaks

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -25,7 +25,7 @@ public class EngineConfig {
     public boolean pondering = false;
     public boolean searchCancelled = false;
 
-    public final Tunable aspMargin              = new Tunable("AspMargin", 20, 0, 250, 25);
+    public final Tunable aspMargin              = new Tunable("AspMargin", 12, 0, 250, 25);
     public final Tunable aspFailMargin          = new Tunable("AspFailMargin", 105, 0, 300, 25);
     public final Tunable aspMaxReduction        = new Tunable("AspMaxReduction", 0, 0, 5, 1);
     public final Tunable nmpDepth               = new Tunable("NmpDepth", 0, 0, 6, 1);


### PR DESCRIPTION
```
Elo   | 2.26 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.30 (-2.89, 2.25) [0.00, 5.00]
Games | N: 37162 W: 8773 L: 8531 D: 19858
Penta | [352, 4411, 8838, 4603, 377]
```
https://kelseyde.pythonanywhere.com/test/23/

bench 6738478