### PR TITLE
Stop doing futility pruning in check

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -378,6 +378,7 @@ public class Searcher implements Search {
             // If the static evaluation + some margin is still < alpha, and the current move is not interesting (checks,
             // captures, promotions), then let's assume it will fail low and prune this node.
             if (!pvNode
+                    && !inCheck
                     && depth <= config.fpDepth.value
                     && scoredMove.isQuiet()) {
 


### PR DESCRIPTION
Not a great idea when staticEval = Integer.MIN_VALUE...

```
Elo   | 6.36 +- 4.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.25 (-2.89, 2.25) [0.00, 5.00]
Games | N: 6230 W: 1508 L: 1394 D: 3328
Penta | [60, 688, 1517, 778, 72]
```
https://kelseyde.pythonanywhere.com/test/25/


bench 5977743