### PR TITLE
Increase LMP depth

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -56,7 +56,7 @@ public class EngineConfig {
     public final Tunable lmrCapDivisor          = new Tunable("LmrCapDivisor", 310, 200, 400, 10);
     public final Tunable lmrMinMoves            = new Tunable("LmrMinMoves", 3, 2, 5, 1);
     public final Tunable lmrMinPvMoves          = new Tunable("LmrMinPvMoves", 4, 2, 5, 1);
-    public final Tunable lmpDepth               = new Tunable("LmpDepth", 4, 0, 8, 1);
+    public final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
     public final Tunable lmpMultiplier          = new Tunable("LmpMultiplier", 8, 1, 20, 1);
     public final Tunable iirDepth               = new Tunable("IirDepth", 3, 0, 8, 1);
     public final Tunable dpMargin               = new Tunable("DpMargin", 111, 0, 250, 10);


### PR DESCRIPTION
```
Elo   | 5.38 +- 4.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 5.00]
Games | N: 7616 W: 1806 L: 1688 D: 4122
Penta | [51, 890, 1823, 978, 66]
```
https://kelseyde.pythonanywhere.com/test/44/

bench 4344458