### PR TITLE
Bug fixes for MoveGenerator isPseudoLegal and getMoves (most in chess960)

### DIFF
--- a/src/main/java/com/kelseyde/calvin/movegen/MoveGenerator.java
+++ b/src/main/java/com/kelseyde/calvin/movegen/MoveGenerator.java
@@ -346,13 +346,18 @@ public class MoveGenerator {
 
     private void generateChess960CastlingMove(Board board, boolean white, boolean kingside, int kingSquare, long occupied) {
         final int rookSquare = Castling.getRook(board.getState().rights, kingside, white);
+        final long rookSquareBit = Bits.of(rookSquare); 
+        if ((pinMask & rookSquareBit) != 0) {
+            // can't castle if rook is pinned 
+        	return;
+        }
         final int kingDst = Castling.kingTo(kingside, white);
         final int rookDst = Castling.rookTo(kingside, white);
 
         final long kingTravelSquares = (Ray.between(kingSquare, kingDst) | Bits.of(kingDst));
         final long rookTravelSquares = (Ray.between(rookSquare, rookDst) | Bits.of(rookDst));
         // Warning : King and rook initial positions should be ignored when verifying if cells are free
-        final long travelSquares = (kingTravelSquares | rookTravelSquares) & ~ (Bits.of(rookSquare) | Bits.of(kingSquare));
+        final long travelSquares = (kingTravelSquares | rookTravelSquares) & ~ (rookSquareBit | Bits.of(kingSquare));
 
         final long blockedSquares = travelSquares & occupied;
         final long safeSquares = Bits.of(kingSquare) | Ray.between(kingSquare, kingDst) | Bits.of(kingDst);

--- a/src/main/java/com/kelseyde/calvin/movegen/MoveGenerator.java
+++ b/src/main/java/com/kelseyde/calvin/movegen/MoveGenerator.java
@@ -709,9 +709,9 @@ public class MoveGenerator {
             final int rookSquare = Castling.getRook(board.getState().rights, kingside, white);
             final long travelSquares = Ray.between(from, rookSquare);
             final long blockedSquares = travelSquares & occupied;
-            final long safeSquares = Bits.of(from) | travelSquares;
+            final long safeSquares = Bits.of(from) | Ray.between(from, to) | Bits.of(to);
 
-            // Can't castle through check
+            // Can't castle through check or occupied cell
             return blockedSquares == 0 && !isAttacked(board, white, safeSquares);
 
         }

--- a/src/test/java/com/kelseyde/calvin/movegen/Chess960Test.java
+++ b/src/test/java/com/kelseyde/calvin/movegen/Chess960Test.java
@@ -169,12 +169,18 @@ public class Chess960Test {
 		assertMove(board, move, true);
 	}
 
+	@Test
+	void testPinnedRookCastling() {
+		// Test castling where king seems safe ... but is not because it does not move and the rook does not defend it anymore
+		final Board board = Board.from("nrk1brnb/pp1ppppp/8/2p5/3P4/1N1Q1N2/1PP1PPPP/qRK1BR1B w KQkq - 2 10");
+		final Move move = Move.fromUCI("c1b1", Move.CASTLE_FLAG);
+		assertMove(board, move, false);
+	}
 
     private void assertMove(Board board, Move move, boolean exists) {
         List<Move> moves = MOVEGEN.generateMoves(board);
         Assertions.assertEquals(exists, moves.stream().anyMatch(m -> m.equals(move)));
-    	final boolean isPseudoLegal = MOVEGEN.isPseudoLegal(board, move);
-		Assertions.assertEquals(exists, isPseudoLegal);
+		Assertions.assertEquals(exists, MOVEGEN.isLegal(board, move));
     }
 
     private void assertKingAndRook(Board board, String kingFrom, String kingTo, String rookFrom, String rookTo) {

--- a/src/test/java/com/kelseyde/calvin/movegen/Chess960Test.java
+++ b/src/test/java/com/kelseyde/calvin/movegen/Chess960Test.java
@@ -160,10 +160,21 @@ public class Chess960Test {
         assertMove(board, queenside, false);
 
     }
+    
+	@Test
+	void testKingDoesntMoveCastling() {
+		// Rook is attacked, but the castling is legal
+		final Board board = Board.from("nrk2rnb/pp1ppppp/6b1/q1p5/3P2Q1/1N3N2/1P2PPPP/1RK1BR1B w KQkq - 2 10");
+		final Move move = Move.fromUCI("c1b1", Move.CASTLE_FLAG);
+		assertMove(board, move, true);
+	}
+
 
     private void assertMove(Board board, Move move, boolean exists) {
         List<Move> moves = MOVEGEN.generateMoves(board);
         Assertions.assertEquals(exists, moves.stream().anyMatch(m -> m.equals(move)));
+    	final boolean isPseudoLegal = MOVEGEN.isPseudoLegal(board, move);
+		Assertions.assertEquals(exists, isPseudoLegal);
     }
 
     private void assertKingAndRook(Board board, String kingFrom, String kingTo, String rookFrom, String rookTo) {

--- a/src/test/java/com/kelseyde/calvin/movegen/PseudoLegalTest.java
+++ b/src/test/java/com/kelseyde/calvin/movegen/PseudoLegalTest.java
@@ -17,10 +17,15 @@ public class PseudoLegalTest {
     @Test
     public void testIsLegalDebug() {
 
+		// Test king side castling
         Board board = Board.from("r3k2r/p1p1qpb1/bn1ppnpB/3PN3/1p2P3/1PN2Q1p/P1P1BPPP/R3K2R b KQkq - 0 2");
         Move move = Move.fromUCI("e8g8", Move.CASTLE_FLAG);
         Assertions.assertTrue(movegen.isPseudoLegal(board, move));
 
+		// Test queen side castling
+        board = Board.from("r3k2r/2pb1ppp/2pp1q2/1Q6/pnP1B3/1P2P3/P2N1PPP/R3K2R b KQkq - 1 2");
+		move = Move.fromUCI("e8c8", Move.CASTLE_FLAG);
+		Assertions.assertTrue(movegen.isPseudoLegal(board, move));
     }
 
     // Disabled as it takes a long time - used for debugging


### PR DESCRIPTION
Hello,

Here are the minor bugs fixed by this pull request:
- MoveGenerator.isPseudoLegal returned false on some queen side standard castling.
- MoveGenerator.isPseudoLegal did not work with chess960.
- MoveGenerator.getMoves did not return castling move when king did not
move and rook traverses it (see test
Chess960Test.testKingDoesntMoveCastling).

I also want to thank you warmly for sharing this code, as efficient as it is clear.  
I would like to reuse it, if you agree, I will open an issue/proposal about how to do that.

Best regards

Jean-Marc