### PR TITLE
Remove 'depth' parameter from Q-search

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -44,7 +44,7 @@ public class EngineConfig {
     public final Tunable seeNoisyMargin         = new Tunable("SeeNoisyMargin", -20, -250, -10, 25);
     public final Tunable seeNoisyOffset         = new Tunable("SeeNoisyOffset", 15, -100, 200, 50);
     public final Tunable qsFpMargin             = new Tunable("QsFpMargin", 99, 0, 250, 10);
-    public final Tunable qsSeeEqualDepth        = new Tunable("QsSeeEqualDepth", 3, 0, 6, 1);
+    public final Tunable qsSeeThreshold         = new Tunable("QsSeeThreshold", 0, -300, 300, 100);
     public final Tunable rfpDepth               = new Tunable("RfpDepth", 7, 0, 8, 1);
     public final Tunable rfpMargin              = new Tunable("RfpMargin", 86, 0, 250, 25);
     public final Tunable rfpImpMargin           = new Tunable("RfpImpMargin", 43, 0, 250, 25);
@@ -104,7 +104,7 @@ public class EngineConfig {
                 aspMargin, aspFailMargin, aspMaxReduction, nmpDepth, nmpEvalScale, nmpEvalMaxReduction, fpDepth, fpBlend,
                 rfpDepth, lmrDepth, lmrBase, lmrDivisor, lmrCapBase, lmrCapDivisor, lmrMinMoves, lmrMinPvMoves, lmpDepth,
                 lmpMultiplier, iirDepth, nmpMargin, nmpImpMargin, nmpBase, nmpDivisor, dpMargin, qsFpMargin,
-                qsSeeEqualDepth, fpMargin, fpScale, rfpMargin, rfpImpMargin, rfpBlend, razorDepth, razorMargin,
+                qsSeeThreshold, fpMargin, fpScale, rfpMargin, rfpImpMargin, rfpBlend, razorDepth, razorMargin,
                 hpMaxDepth, hpMargin, hpOffset, quietHistBonusMax, quietHistBonusScale, quietHistMalusMax,
                 quietHistMalusScale, quietHistMaxScore, captHistBonusMax, captHistBonusScale, captHistMalusMax,
                 captHistMalusScale, captHistMaxScore, contHistBonusMax, contHistBonusScale, contHistMalusMax,

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -179,7 +179,7 @@ public class Searcher implements Search {
         final boolean pvNode = beta - alpha > 1;
 
         // If depth is reached, drop into quiescence search
-        if (depth <= 0 && !inCheck) return quiescenceSearch(alpha, beta, 1, ply);
+        if (depth <= 0 && !inCheck) return quiescenceSearch(alpha, beta, ply);
         if (depth < 0) depth = 0;
 
         // If the game is drawn by repetition, insufficient material or fifty move rule, return zero
@@ -303,7 +303,7 @@ public class Searcher implements Search {
             if (depth <= config.razorDepth.value
                 && staticEval + config.razorMargin.value * depth < alpha) {
 
-                final int score = quiescenceSearch(alpha, alpha + 1, 1, ply);
+                final int score = quiescenceSearch(alpha, alpha + 1, ply);
                 if (score < alpha) {
                     return score;
                 }
@@ -572,7 +572,7 @@ public class Searcher implements Search {
      *
      * @see <a href="https://www.chessprogramming.org/Quiescence_Search">Chess Programming Wiki</a>
      */
-    int quiescenceSearch(int alpha, int beta, int depth, int ply) {
+    int quiescenceSearch(int alpha, int beta, int ply) {
 
         if (shouldStop()) {
             return alpha;
@@ -683,15 +683,14 @@ public class Searcher implements Search {
             // SEE Pruning - https://www.chessprogramming.org/Static_Exchange_Evaluation
             // Evaluate the possible captures + recaptures on the target square, in order to filter out losing capture
             // chains, such as capturing with the queen a pawn defended by another pawn.
-            final int seeThreshold = depth <= config.qsSeeEqualDepth.value ? 0 : 1;
-            if (!inCheck && !SEE.see(board, move, seeThreshold)) {
+            if (!inCheck && !SEE.see(board, move, 0)) {
                 continue;
             }
 
             eval.makeMove(board, move);
             if (!board.makeMove(move)) continue;
             td.nodes++;
-            final int score = -quiescenceSearch(-beta, -alpha, depth + 1, ply + 1);
+            final int score = -quiescenceSearch(-beta, -alpha, ply + 1);
             eval.unmakeMove();
             board.unmakeMove();
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -683,7 +683,7 @@ public class Searcher implements Search {
             // SEE Pruning - https://www.chessprogramming.org/Static_Exchange_Evaluation
             // Evaluate the possible captures + recaptures on the target square, in order to filter out losing capture
             // chains, such as capturing with the queen a pawn defended by another pawn.
-            if (!inCheck && !SEE.see(board, move, 0)) {
+            if (!inCheck && !SEE.see(board, move, config.qsSeeThreshold.value)) {
                 continue;
             }
 


### PR DESCRIPTION
And use 0 as a flat threshold for Q-search SEE pruning

STC: 
```
Elo   | 3.93 +- 3.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.27 (-2.89, 2.25) [0.00, 5.00]
Games | N: 12104 W: 2874 L: 2737 D: 6493
Penta | [108, 1383, 2950, 1486, 125]
```
https://kelseyde.pythonanywhere.com/test/71/
