### PR TITLE
Average static eval and raw eval in corrhist updates

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -571,7 +571,7 @@ public class Searcher implements Search {
             && !(flag == HashFlag.LOWER && uncorrectedStaticEval >= bestScore)
             && !(flag == HashFlag.UPPER && uncorrectedStaticEval <= bestScore)) {
             // Update the correction history table with the current search score, to improve future static evaluations.
-            history.updateCorrectionHistory(board, ss, ply, depth, bestScore, uncorrectedStaticEval);
+            history.updateCorrectionHistory(board, ss, ply, depth, bestScore, (uncorrectedStaticEval + staticEval) / 2);
         }
 
         // Store the best move and score in the transposition table for future reference.


### PR DESCRIPTION
STC:
```
Elo   | 19.34 +- 9.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.28 (-2.89, 2.25) [0.00, 5.00]
Games | N: 1780 W: 463 L: 364 D: 953
Penta | [15, 180, 405, 271, 19]
```
https://kelseyde.pythonanywhere.com/test/98/
bench 5073570