### PR TITLE
Use just static eval in corrhist updates

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -571,7 +571,7 @@ public class Searcher implements Search {
             && !(flag == HashFlag.LOWER && uncorrectedStaticEval >= bestScore)
             && !(flag == HashFlag.UPPER && uncorrectedStaticEval <= bestScore)) {
             // Update the correction history table with the current search score, to improve future static evaluations.
-            history.updateCorrectionHistory(board, ss, ply, depth, bestScore, (uncorrectedStaticEval + staticEval) / 2);
+            history.updateCorrectionHistory(board, ss, ply, depth, bestScore, staticEval);
         }
 
         // Store the best move and score in the transposition table for future reference.


### PR DESCRIPTION
STC:
```
Elo   | 3.30 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.32 (-2.89, 2.25) [0.00, 5.00]
Games | N: 16448 W: 3873 L: 3717 D: 8858
Penta | [139, 1926, 3943, 2072, 144]
```
https://kelseyde.pythonanywhere.com/test/99/

bench 5103163