### PR TITLE
Switch history tables to use i16s

### DIFF
--- a/src/main/java/com/kelseyde/calvin/tables/correction/HashCorrectionTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/correction/HashCorrectionTable.java
@@ -9,10 +9,10 @@ public class HashCorrectionTable extends CorrectionHistoryTable {
 
     private static final int TABLE_SIZE = 16384;
 
-    int[][] entries;
+    short[][] entries;
 
     public HashCorrectionTable() {
-        this.entries = new int[2][TABLE_SIZE];
+        this.entries = new short[2][TABLE_SIZE];
     }
 
     public void update(long key, boolean white, int depth, int score, int staticEval) {
@@ -30,12 +30,12 @@ public class HashCorrectionTable extends CorrectionHistoryTable {
     private void put(long key, boolean white, int value) {
         int colourIndex = Colour.index(white);
         int hashIndex = hashIndex(key);
-        entries[colourIndex][hashIndex] = value;
+        entries[colourIndex][hashIndex] = (short) value;
     }
 
     @Override
     public void clear() {
-        this.entries = new int[2][TABLE_SIZE];
+        this.entries = new short[2][TABLE_SIZE];
     }
 
     private int hashIndex(long key) {

--- a/src/main/java/com/kelseyde/calvin/tables/correction/PieceToCorrectionTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/correction/PieceToCorrectionTable.java
@@ -10,10 +10,10 @@ import com.kelseyde.calvin.board.Piece;
  */
 public class PieceToCorrectionTable extends CorrectionHistoryTable {
 
-    int[][][] entries;
+    short[][][] entries;
 
     public PieceToCorrectionTable() {
-        this.entries = new int[2][Piece.COUNT][Square.COUNT];
+        this.entries = new short[2][Piece.COUNT][Square.COUNT];
     }
 
     public void update(Move prevMove, Piece prevPiece, boolean white, int staticEval, int score, int depth) {
@@ -34,12 +34,12 @@ public class PieceToCorrectionTable extends CorrectionHistoryTable {
         int colourIndex = Colour.index(white);
         int pieceIndex = prevPiece.index();
         int to = prevMove.to();
-        entries[colourIndex][pieceIndex][to] = value;
+        entries[colourIndex][pieceIndex][to] = (short) value;
     }
 
     @Override
     public void clear() {
-        this.entries = new int[2][Piece.COUNT][Square.COUNT];
+        this.entries = new short[2][Piece.COUNT][Square.COUNT];
     }
 
 }

--- a/src/main/java/com/kelseyde/calvin/tables/history/AbstractHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/AbstractHistoryTable.java
@@ -2,13 +2,13 @@ package com.kelseyde.calvin.tables.history;
 
 public abstract class AbstractHistoryTable {
 
-    private final int bonusMax;
-    private final int bonusScale;
-    private final int malusMax;
-    private final int malusScale;
-    private final int scoreMax;
+    private final short bonusMax;
+    private final short bonusScale;
+    private final short malusMax;
+    private final short malusScale;
+    private final short scoreMax;
 
-    public AbstractHistoryTable(int bonusMax, int bonusScale, int malusMax, int malusScale, int scoreMax) {
+    public AbstractHistoryTable(short bonusMax, short bonusScale, short malusMax, short malusScale, short scoreMax) {
         this.bonusMax = bonusMax;
         this.bonusScale = bonusScale;
         this.malusMax = malusMax;
@@ -16,16 +16,16 @@ public abstract class AbstractHistoryTable {
         this.scoreMax = scoreMax;
     }
 
-    protected int bonus(int depth) {
-        return Math.min(bonusScale * depth, bonusMax);
+    protected short bonus(int depth) {
+        return (short) Math.min(bonusScale * depth, bonusMax);
     }
 
-    protected int malus(int depth) {
-        return -Math.min(malusScale * depth, malusMax);
+    protected short malus(int depth) {
+        return (short) -Math.min(malusScale * depth, malusMax);
     }
 
-    protected int gravity(int current, int update) {
-        return current + update - current * Math.abs(update) / scoreMax;
+    protected short gravity(short current, short update) {
+        return (short) (current + update - current * Math.abs(update) / scoreMax);
     }
 
 }

--- a/src/main/java/com/kelseyde/calvin/tables/history/CaptureHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/CaptureHistoryTable.java
@@ -7,23 +7,23 @@ import com.kelseyde.calvin.engine.EngineConfig;
 
 public class CaptureHistoryTable extends AbstractHistoryTable {
 
-    int[][][][] table = new int[2][Piece.COUNT][Square.COUNT][Piece.COUNT];
+    short[][][][] table = new short[2][Piece.COUNT][Square.COUNT][Piece.COUNT];
 
     public CaptureHistoryTable(EngineConfig config) {
-        super(config.captHistBonusMax.value,
-                config.captHistBonusScale.value,
-                config.captHistMalusMax.value,
-                config.captHistMalusScale.value,
-                config.captHistMaxScore.value);
+        super((short) config.captHistBonusMax.value,
+                (short) config.captHistBonusScale.value,
+                (short) config.captHistMalusMax.value,
+                (short) config.captHistMalusScale.value,
+                (short) config.captHistMaxScore.value);
     }
 
     public void update(Piece piece, int to, Piece captured, int depth, boolean white, boolean good) {
         int colourIndex = Colour.index(white);
         int pieceIndex = piece.index();
         int capturedIndex = captured.index();
-        int current = table[colourIndex][pieceIndex][to][capturedIndex];
-        int bonus = good ? bonus(depth) : malus(depth);
-        int update = gravity(current, bonus);
+        short current = table[colourIndex][pieceIndex][to][capturedIndex];
+        short bonus = good ? bonus(depth) : malus(depth);
+        short update = gravity(current, bonus);
         table[colourIndex][pieceIndex][to][capturedIndex] = update;
     }
 
@@ -35,7 +35,7 @@ public class CaptureHistoryTable extends AbstractHistoryTable {
     }
 
     public void clear() {
-        table = new int[2][Piece.COUNT][Square.COUNT][Piece.COUNT];
+        table = new short[2][Piece.COUNT][Square.COUNT][Piece.COUNT];
     }
 
 }

--- a/src/main/java/com/kelseyde/calvin/tables/history/ContinuationHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/ContinuationHistoryTable.java
@@ -8,24 +8,24 @@ import com.kelseyde.calvin.engine.EngineConfig;
 
 public class ContinuationHistoryTable extends AbstractHistoryTable {
 
-    int[][][][][] table = new int[2][Piece.COUNT][Square.COUNT][Piece.COUNT][Square.COUNT];
+    short[][][][][] table = new short[2][Piece.COUNT][Square.COUNT][Piece.COUNT][Square.COUNT];
 
     public ContinuationHistoryTable(EngineConfig config) {
-        super(config.contHistBonusMax.value,
-                config.contHistBonusScale.value,
-                config.contHistMalusMax.value,
-                config.contHistMalusScale.value,
-                config.contHistMaxScore.value);
+        super((short) config.contHistBonusMax.value,
+                (short) config.contHistBonusScale.value,
+                (short) config.contHistMalusMax.value,
+                (short) config.contHistMalusScale.value,
+                (short) config.contHistMaxScore.value);
     }
 
     public void update(Move prevMove, Piece prevPiece, Move currMove, Piece currPiece, int depth, boolean white, boolean good) {
-        int current = get(prevMove, prevPiece, currMove, currPiece, white);
-        int bonus = good ? bonus(depth) : malus(depth);
-        int update = gravity(current, bonus);
+        short current = get(prevMove, prevPiece, currMove, currPiece, white);
+        short bonus = good ? bonus(depth) : malus(depth);
+        short update = gravity(current, bonus);
         set(prevMove, prevPiece, currMove, currPiece, update, white);
     }
 
-    public int get(Move prevMove, Piece prevPiece, Move currMove, Piece currPiece, boolean white) {
+    public short get(Move prevMove, Piece prevPiece, Move currMove, Piece currPiece, boolean white) {
         if (prevMove == null || prevPiece == null || currMove == null || currPiece == null) {
             return 0;
         }
@@ -33,7 +33,7 @@ public class ContinuationHistoryTable extends AbstractHistoryTable {
         return table[colourIndex][prevPiece.index()][prevMove.to()][currPiece.index()][currMove.to()];
     }
 
-    public void set(Move prevMove, Piece prevPiece, Move currMove, Piece currPiece, int update, boolean white) {
+    public void set(Move prevMove, Piece prevPiece, Move currMove, Piece currPiece, short update, boolean white) {
         if (prevMove == null || prevPiece == null || currMove == null || currPiece == null) {
             return;
         }
@@ -42,7 +42,7 @@ public class ContinuationHistoryTable extends AbstractHistoryTable {
     }
 
     public void clear() {
-        table = new int[2][Piece.COUNT][Square.COUNT][Piece.COUNT][Square.COUNT];
+        table = new short[2][Piece.COUNT][Square.COUNT][Piece.COUNT][Square.COUNT];
     }
 
 }

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -8,31 +8,31 @@ import com.kelseyde.calvin.engine.EngineConfig;
 
 public class QuietHistoryTable extends AbstractHistoryTable {
 
-    int[][][] table = new int[2][Piece.COUNT][Square.COUNT];
+    short[][][] table = new short[2][Piece.COUNT][Square.COUNT];
 
     public QuietHistoryTable(EngineConfig config) {
-        super(config.quietHistBonusMax.value,
-                config.quietHistBonusScale.value,
-                config.quietHistMalusMax.value,
-                config.quietHistMalusScale.value,
-                config.quietHistMaxScore.value);
+        super((short) config.quietHistBonusMax.value,
+                (short) config.quietHistBonusScale.value,
+                (short) config.quietHistMalusMax.value,
+                (short) config.quietHistMalusScale.value,
+                (short) config.quietHistMaxScore.value);
     }
 
     public void update(Move move, Piece piece, int depth, boolean white, boolean good) {
         int colourIndex = Colour.index(white);
-        int current = table[colourIndex][piece.index()][move.to()];
-        int bonus = good ? bonus(depth) : malus(depth);
-        int update = gravity(current, bonus);
+        short current = table[colourIndex][piece.index()][move.to()];
+        short bonus = good ? bonus(depth) : malus(depth);
+        short update = gravity(current, bonus);
         table[colourIndex][piece.index()][move.to()] = update;
     }
 
-    public int get(Move move, Piece piece, boolean white) {
+    public short get(Move move, Piece piece, boolean white) {
         int colourIndex = Colour.index(white);
         return table[colourIndex][piece.index()][move.to()];
     }
 
     public void clear() {
-        table = new int[2][Piece.COUNT][Square.COUNT];
+        table = new short[2][Piece.COUNT][Square.COUNT];
     }
 
 }


### PR DESCRIPTION
Non-functional.

STC:
```
Elo   | -0.25 +- 3.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.94 (-2.89, 2.25) [-5.00, 0.00]
Games | N: 11210 W: 2567 L: 2575 D: 6068
Penta | [82, 1229, 2996, 1211, 87]
```
https://kelseyde.pythonanywhere.com/test/126/

bench 5075540