### PR TITLE
Fix futility reductions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -306,8 +306,8 @@ public class Searcher implements Search {
                 int baseMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value);
                 int blend = depth * config.rfpBlend.value;
 
-                int pruneMargin = baseMargin - blend;
-                int reduceMargin = baseMargin + blend;
+                int pruneMargin = baseMargin + blend;
+                int reduceMargin = baseMargin - blend;
 
                 // If the evaluation is significantly higher than beta, prune the node entirely
                 if (staticEval - pruneMargin >= beta) {
@@ -428,7 +428,7 @@ public class Searcher implements Search {
                     int pruneMargin = config.fpMargin.value
                             + (depth - reduction) * config.fpScale.value
                             + (historyScore / config.fpHistDivisor.value);
-                    int reduceMargin = pruneMargin + depth * config.fpBlend.value;
+                    int reduceMargin = pruneMargin - depth * config.fpBlend.value;
 
                     if (staticEval + pruneMargin <= alpha) {
                         sse.currentMove = null;


### PR DESCRIPTION
Not sure how I could have messed this up so badly...

STC:
```
Elo   | 4.77 +- 4.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 8960 W: 2101 L: 1978 D: 4881
Penta | [69, 1028, 2179, 1119, 85]
```

https://kelseyde.pythonanywhere.com/test/134/

bench 5779060