### PR TITLE
Remove RFP futility reductions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -303,21 +303,11 @@ public class Searcher implements Search {
             // is a cut-node and will fail-high, and not search any further.
             if (depth <= config.rfpDepth.value && !Score.isMateScore(alpha)) {
 
-                int baseMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value);
-                int blend = depth * config.rfpBlend.value;
+                final int futilityMargin = depth * (improving ? config.rfpImpMargin.value : config.rfpMargin.value)
+                        + depth * config.rfpBlend.value;
 
-                int pruneMargin = baseMargin + blend;
-                int reduceMargin = baseMargin - blend;
-
-                // If the evaluation is significantly higher than beta, prune the node entirely
-                if (staticEval - pruneMargin >= beta) {
+                if (staticEval - futilityMargin >= beta) {
                     return beta + (staticEval - beta) / 3;
-                }
-                // Else, apply reduction to quiet moves, using a dynamic scaling based on how far the eval is from beta
-                else if (staticEval - reduceMargin >= beta) {
-                    // Calculate distance from beta in units of 'blend' to scale reduction dynamically
-                    int delta = (staticEval - beta) - reduceMargin;
-                    futilityReduction = 1 + Math.min(2, delta / blend);
                 }
             }
 


### PR DESCRIPTION
Should have run this as a non-reg - it could be it loses a fractional amount of elo, but it's a simplification I quite like, so I'm merging it.

```
Elo   | -0.96 +- 3.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -1.90 (-2.89, 2.25) [0.00, 5.00]
Games | N: 10890 W: 2431 L: 2461 D: 5998
Penta | [89, 1341, 2620, 1301, 94]
```

https://kelseyde.pythonanywhere.com/test/137/

bench 5209072