### PR TITLE
Improve history LMR

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -62,8 +62,8 @@ public class EngineConfig {
     private final Tunable lmrPvNode              = new Tunable("LmrPvNode", 1024, 0, 2048, 150);
     private final Tunable lmrCutNode             = new Tunable("LmrPvNode", 0, 0, 2048, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 0, 0, 2048, 150);
-    private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 6144, 3072, 12288, 1000);
-    private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 6144, 3072, 12288, 1000);
+    private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3072, 1536, 6144, 1000);
+    private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3072, 1536, 6144, 1000);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
     private final Tunable lmpMultiplier          = new Tunable("LmpMultiplier", 8, 1, 20, 1);
     private final Tunable iirDepth               = new Tunable("IirDepth", 4, 0, 8, 1);

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -62,8 +62,8 @@ public class EngineConfig {
     private final Tunable lmrPvNode              = new Tunable("LmrPvNode", 1024, 0, 2048, 150);
     private final Tunable lmrCutNode             = new Tunable("LmrPvNode", 0, 0, 2048, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 0, 0, 2048, 150);
-    private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3072, 12288, 6144, 1000);
-    private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3072, 12288, 6144, 1000);
+    private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 6144, 3072, 12288, 1000);
+    private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 6144, 3072, 12288, 1000);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
     private final Tunable lmpMultiplier          = new Tunable("LmpMultiplier", 8, 1, 20, 1);
     private final Tunable iirDepth               = new Tunable("IirDepth", 4, 0, 8, 1);

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -62,6 +62,8 @@ public class EngineConfig {
     private final Tunable lmrPvNode              = new Tunable("LmrPvNode", 1024, 0, 2048, 150);
     private final Tunable lmrCutNode             = new Tunable("LmrPvNode", 0, 0, 2048, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 0, 0, 2048, 150);
+    private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3072, 12288, 6144, 1000);
+    private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3072, 12288, 6144, 1000);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
     private final Tunable lmpMultiplier          = new Tunable("LmpMultiplier", 8, 1, 20, 1);
     private final Tunable iirDepth               = new Tunable("IirDepth", 4, 0, 8, 1);
@@ -118,7 +120,7 @@ public class EngineConfig {
                 nodeTmScale, ttExtensionDepth, seeMaxDepth, seeQuietMargin, seeNoisyMargin, seeNoisyOffset,
                 seeHistoryDivisor, timeFactor, incrementFactor, softTimeFactor, hardTimeFactor, softTimeScaleMin,
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
-                seeQsNoisyDivisor, seeQsNoisyOffset
+                seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv
         );
     }
 
@@ -342,6 +344,14 @@ public class EngineConfig {
 
     public int lmrNotImproving() {
         return lmrNotImproving.value;
+    }
+
+    public int lmrQuietHistoryDiv() {
+        return lmrQuietHistoryDiv.value;
+    }
+
+    public int lmrNoisyHistoryDiv() {
+        return lmrNoisyHistoryDiv.value;
     }
 
     public int lmpDepth() {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -394,7 +394,9 @@ public class Searcher implements Search {
                 r -= pvNode ? config.lmrPvNode() : 0;
                 r += cutNode ? config.lmrCutNode() : 0;
                 r += !improving ? config.lmrNotImproving() : 0;
-                r -= (2 * historyScore / config.quietHistMaxScore()) * 1024;
+                r -= scoredMove.isQuiet()
+                        ? historyScore / config.lmrQuietHistoryDiv() * 1024
+                        : historyScore / config.lmrNoisyHistoryDiv() * 1024;
 
                 reduction = Math.max(0, r / 1024);
             }


### PR DESCRIPTION
STC:

```
Elo   | 5.28 +- 4.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 7694 W: 1804 L: 1687 D: 4203
Penta | [53, 878, 1886, 959, 71]
```

https://kelseyde.pythonanywhere.com/test/149/

bench 5173416