### PR TITLE
Only skip SEE pruning for good noisies

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -443,7 +443,7 @@ public class Searcher implements Search {
                 // Prune moves that lose material beyond a certain threshold, once all the pieces have been exchanged.
                 if (depth <= config.seeMaxDepth()
                         && movesSearched > 1
-                        && (scoredMove.isQuiet() || (scoredMove.isBadNoisy() && isCapture))
+                        && !scoredMove.isGoodNoisy()
                         && !Score.isMateScore(bestScore)) {
 
                     int threshold = scoredMove.isQuiet() ?


### PR DESCRIPTION
Let's go

```
Elo   | 11.30 +- 6.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.29 (-2.89, 2.25) [0.00, 5.00]
Games | N: 3046 W: 748 L: 649 D: 1649
Penta | [19, 321, 753, 402, 28]
```
https://kelseyde.pythonanywhere.com/test/154/

bench 4361925