### PR TITLE
Smaller capthist divisor

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/picker/MoveScorer.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MoveScorer.java
@@ -79,7 +79,7 @@ public class MoveScorer {
         score += SEE.value(captured);
 
         final int historyScore = history.getCaptureHistoryTable().get(piece, move.to(), captured, board.isWhite());
-        score += historyScore / 8;
+        score += historyScore / 4;
 
         final int threshold = -score / seeNoisyDivisor + seeNoisyOffset;
 


### PR DESCRIPTION
STC:
```
Elo   | 2.83 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 20120 W: 4558 L: 4394 D: 11168
Penta | [141, 2308, 5019, 2430, 162]
```
https://kelseyde.pythonanywhere.com/test/171/

bench 4260855