### PR TITLE
Futility LMR

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -62,6 +62,7 @@ public class EngineConfig {
     private final Tunable lmrPvNode              = new Tunable("LmrPvNode", 915, 0, 2048, 150);
     private final Tunable lmrCutNode             = new Tunable("LmrPvNode", 0, 0, 2048, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 5, 0, 2048, 150);
+    private final Tunable lmrFutile              = new Tunable("LmrFutile", 1024, 0, 2048, 150);
     private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 2993, 1536, 6144, 1000);
     private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3154, 1536, 6144, 1000);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
@@ -113,7 +114,7 @@ public class EngineConfig {
                 fpHistDivisor, rfpDepth, lmrDepth, lmrBase, lmrDivisor, lmrCapBase, lmrCapDivisor, lmrMinMoves,
                 lmrMinPvMoves, lmpDepth, lmpMultiplier, iirDepth, nmpBase, nmpDivisor, dpMargin, qsFpMargin,
                 qsSeeThreshold, fpMargin, fpScale, rfpMargin, rfpImpMargin, rfpBlend, razorDepth, razorMargin,
-                hpMaxDepth, hpMargin, hpOffset, lmrPvNode, lmrCutNode, lmrNotImproving, quietHistBonusMax,
+                hpMaxDepth, hpMargin, hpOffset, lmrPvNode, lmrCutNode, lmrNotImproving, lmrFutile, quietHistBonusMax,
                 quietHistBonusScale, quietHistMalusMax, quietHistMalusScale, quietHistMaxScore, captHistBonusMax,
                 captHistBonusScale, captHistMalusMax, captHistMalusScale, captHistMaxScore, contHistBonusMax,
                 contHistBonusScale, contHistMalusMax, contHistMalusScale, contHistMaxScore, nodeTmMinDepth, nodeTmBase,
@@ -351,6 +352,10 @@ public class EngineConfig {
 
     public int lmrNotImproving() {
         return lmrNotImproving.value;
+    }
+
+    public int lmrFutile() {
+        return lmrFutile.value;
     }
 
     public int lmrQuietHistoryDiv() {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -398,6 +398,12 @@ public class Searcher implements Search {
                         ? historyScore / config.lmrQuietHistoryDiv() * 1024
                         : historyScore / config.lmrNoisyHistoryDiv() * 1024;
 
+                final int futilityMargin = config.fpMargin()
+                        + (depth) * config.fpScale()
+                        + (historyScore / config.fpHistDivisor());
+                final boolean futile = staticEval + futilityMargin <= alpha;
+                r += futile ? config.lmrFutile() : 0;
+
                 reduction = Math.max(0, r / 1024);
             }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -398,11 +398,10 @@ public class Searcher implements Search {
                         ? historyScore / config.lmrQuietHistoryDiv() * 1024
                         : historyScore / config.lmrNoisyHistoryDiv() * 1024;
 
-                final int futilityMargin = config.fpMargin()
+                int futilityMargin = config.fpMargin()
                         + (depth) * config.fpScale()
                         + (historyScore / config.fpHistDivisor());
-                final boolean futile = staticEval + futilityMargin <= alpha;
-                r += futile ? config.lmrFutile() : 0;
+                r += staticEval + futilityMargin <= alpha ? config.lmrFutile() : 0;
 
                 reduction = Math.max(0, r / 1024);
             }


### PR DESCRIPTION
STC:
```
Elo   | 4.49 +- 3.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 9354 W: 2133 L: 2012 D: 5209
Penta | [67, 1033, 2353, 1160, 64]
```
https://kelseyde.pythonanywhere.com/test/232/

bench 4541662