### PR TITLE
Double extensions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -79,6 +79,7 @@ public class EngineConfig {
     private final Tunable seBetaMargin           = new Tunable("SeBetaMargin", 32, 12, 40, 4);
     private final Tunable seReductionOffset      = new Tunable("SeReductionOffset", 1, 0, 3, 1);
     private final Tunable seReductionDivisor     = new Tunable("SeReductionDivisor", 2, 1, 4, 1);
+    private final Tunable seDoubleExtMargin      = new Tunable("SeDoubleExtMargin", 20, 0, 32, 5);
     private final Tunable ttExtensionDepth       = new Tunable("TtExtDepth", 6, 0, 12, 1);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
@@ -127,7 +128,7 @@ public class EngineConfig {
                 seeHistoryDivisor, timeFactor, incrementFactor, softTimeFactor, hardTimeFactor, softTimeScaleMin,
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
-                seBetaMargin, seReductionOffset, seReductionDivisor
+                seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin
         );
     }
 
@@ -426,6 +427,10 @@ public class EngineConfig {
 
     public int seReductionDivisor() {
         return seReductionDivisor.value;
+    }
+
+    public int seDoubleExtMargin() {
+        return seDoubleExtMargin.value;
     }
 
     public int ttExtensionDepth() {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -495,7 +495,10 @@ public class Searcher implements Search {
                 sse.excludedMove = null;
 
                 if (score < sBeta) {
-                    extension = 1;
+                    if (!pvNode && score < sBeta - config.seDoubleExtMargin())
+                        extension = 2;
+                    else
+                        extension = 1;
                 }
 
             }


### PR DESCRIPTION
```
Elo   | 5.67 +- 4.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 7042 W: 1656 L: 1541 D: 3845
Penta | [52, 799, 1719, 884, 67]
```
https://kelseyde.pythonanywhere.com/test/250/

bench 4496046