### PR TITLE
Don't call evaluate() in singular search

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -271,7 +271,11 @@ public class Searcher implements Search {
         int uncorrectedStaticEval = Integer.MIN_VALUE;
         int staticEval = Integer.MIN_VALUE;
 
-        if (!inCheck) {
+        if (singularSearch) {
+            // In singular search, since we are in the same node, we can re-use the static eval on the stack.
+            staticEval = sse.staticEval;
+        }
+        else if (!inCheck) {
             // Re-use cached static eval if available. Don't compute static eval while in check.
             rawStaticEval = ttHit ? ttEntry.staticEval() : eval.evaluate();
             uncorrectedStaticEval = rawStaticEval;


### PR DESCRIPTION
Passed non-reg:

```
Elo   | 7.04 +- 6.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [-5.00, 0.00]
Games | N: 3604 W: 879 L: 806 D: 1919
Penta | [27, 412, 849, 489, 25]
```
https://kelseyde.pythonanywhere.com/test/261/

bench 4701210