### PR TITLE
Fix `cutnode` usage

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -500,13 +500,13 @@ public class Searcher implements Search {
             int score;
 
             // Principal Variation Search
-            if (pvNode && searchedMoves == 1) {
+            if (searchedMoves == 1) {
                 // Since we expect the first move to be the best, we search it with a full window.
-                score = -search(depth - 1 + extension, ply + 1, -beta, -alpha, false);
+                score = -search(depth - 1 + extension, ply + 1, -beta, -alpha, !pvNode && !cutNode);
             }
             else {
                 // For all other moves, search with a null window.
-                score = -search(depth - 1 - reduction + extension, ply + 1, -alpha - 1, -alpha, true);
+                score = -search(depth - 1 - reduction + extension, ply + 1, -alpha - 1, -alpha, !cutNode);
 
                 if (score > alpha && (score < beta || reduction > 0)) {
                     // If the score beats alpha, we need to do a re-search with the full window and depth.


### PR DESCRIPTION
```
Elo   | 9.44 +- 6.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 3790 W: 926 L: 823 D: 2041
Penta | [33, 402, 927, 495, 38]
```
https://kelseyde.pythonanywhere.com/test/289/

bench 5388612