### PR TITLE
Cutnode LMR

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -60,7 +60,7 @@ public class EngineConfig {
     private final Tunable lmrMinMoves            = new Tunable("LmrMinMoves", 3, 2, 5, 1);
     private final Tunable lmrMinPvMoves          = new Tunable("LmrMinPvMoves", 4, 2, 5, 1);
     private final Tunable lmrPvNode              = new Tunable("LmrPvNode", 915, 0, 2048, 150);
-    private final Tunable lmrCutNode             = new Tunable("LmrPvNode", 0, 0, 2048, 150);
+    private final Tunable lmrCutNode             = new Tunable("LmrCutNode", 2048, 0, 3072, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 5, 0, 2048, 150);
     private final Tunable lmrFutile              = new Tunable("LmrFutile", 1024, 0, 2048, 150);
     private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 2993, 1536, 6144, 1000);


### PR DESCRIPTION
```
Elo   | 5.78 +- 4.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.25 (-2.89, 2.25) [0.00, 5.00]
Games | N: 6734 W: 1604 L: 1492 D: 3638
Penta | [36, 777, 1660, 827, 67]
```
https://kelseyde.pythonanywhere.com/test/291/

bench 5369229