### PR TITLE
Tweak RFP margin

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -49,8 +49,7 @@ public class EngineConfig {
     private final Tunable qsFpMargin             = new Tunable("QsFpMargin", 112, 0, 250, 10);
     private final Tunable qsSeeThreshold         = new Tunable("QsSeeThreshold", 18, -300, 300, 100);
     private final Tunable rfpDepth               = new Tunable("RfpDepth", 9, 0, 12, 1);
-    private final Tunable rfpMargin              = new Tunable("RfpMargin", 85, 0, 250, 25);
-    private final Tunable rfpImpMargin           = new Tunable("RfpImpMargin", 45, 0, 250, 25);
+    private final Tunable rfpMargin              = new Tunable("RfpMargin", 71, 0, 150, 25);
     private final Tunable rfpBlend               = new Tunable("RfpBlend", 4, 1, 10, 2);
     private final Tunable lmrDepth               = new Tunable("LmrDepth", 2, 0, 8, 1);
     private final Tunable lmrBase                = new Tunable("LmrBase", 91, 50, 100, 5);
@@ -119,8 +118,8 @@ public class EngineConfig {
                 aspMinDepth, aspMargin, aspMaxReduction, nmpDepth, nmpEvalScale, nmpEvalMaxReduction, fpDepth, fpBlend,
                 fpHistDivisor, rfpDepth, lmrDepth, lmrBase, lmrDivisor, lmrCapBase, lmrCapDivisor, lmrMinMoves,
                 lmrMinPvMoves, lmpDepth, lmpMultiplier, iirDepth, nmpBase, nmpDivisor, dpMargin, qsFpMargin,
-                qsSeeThreshold, fpMargin, fpScale, rfpMargin, rfpImpMargin, rfpBlend, razorDepth, razorMargin,
-                hpMaxDepth, hpMargin, hpOffset, lmrPvNode, lmrCutNode, lmrNotImproving, lmrFutile, quietHistBonusMax,
+                qsSeeThreshold, fpMargin, fpScale, rfpMargin, rfpBlend, razorDepth, razorMargin, hpMaxDepth,
+                hpMargin, hpOffset, lmrPvNode, lmrCutNode, lmrNotImproving, lmrFutile, quietHistBonusMax,
                 quietHistBonusScale, quietHistMalusMax, quietHistMalusScale, quietHistMaxScore, captHistBonusMax,
                 captHistBonusScale, captHistMalusMax, captHistMalusScale, captHistMaxScore, contHistBonusMax,
                 contHistBonusScale, contHistMalusMax, contHistMalusScale, contHistMaxScore, nodeTmMinDepth, nodeTmBase,
@@ -311,10 +310,6 @@ public class EngineConfig {
 
     public int rfpMargin() {
         return rfpMargin.value;
-    }
-
-    public int rfpImpMargin() {
-        return rfpImpMargin.value;
     }
 
     public int rfpBlend() {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -296,7 +296,7 @@ public class Searcher implements Search {
 
             // Reverse Futility Pruning
             // Skip nodes where the static eval is far above beta and will thus likely result in a fail-high.
-            final int futilityMargin = Math.max(depth - (improving ? 1 : 0), 0) * 71;
+            final int futilityMargin = Math.max(depth - (improving ? 1 : 0), 0) * config.rfpMargin();
             if (depth <= config.rfpDepth()
                     && !Score.isMateScore(alpha)
                     && staticEval - futilityMargin >= beta) {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -296,7 +296,7 @@ public class Searcher implements Search {
 
             // Reverse Futility Pruning
             // Skip nodes where the static eval is far above beta and will thus likely result in a fail-high.
-            final int futilityMargin = depth * (improving ? config.rfpImpMargin() : config.rfpMargin()) + depth * config.rfpBlend();
+            final int futilityMargin = Math.max(depth - (improving ? 1 : 0), 0) * 71;
             if (depth <= config.rfpDepth()
                     && !Score.isMateScore(alpha)
                     && staticEval - futilityMargin >= beta) {


### PR DESCRIPTION
STC:

```
Elo   | 7.40 +- 5.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.26 (-2.89, 2.25) [0.00, 5.00]
Games | N: 4980 W: 1192 L: 1086 D: 2702
Penta | [37, 539, 1244, 621, 49]
```
https://kelseyde.pythonanywhere.com/test/318/

bench 4699795