### PR TITLE
Feature/decrease max corr

### DIFF
--- a/src/main/java/com/kelseyde/calvin/tables/correction/CorrectionHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/correction/CorrectionHistoryTable.java
@@ -19,7 +19,7 @@ import com.kelseyde.calvin.tables.tt.TranspositionTable;
  */
 public abstract class CorrectionHistoryTable {
 
-    public static final int SCALE = 512;
+    public static final int SCALE = 128;
     protected static final int MAX = SCALE * 32;
 
     /**

--- a/src/main/java/com/kelseyde/calvin/tables/correction/CorrectionHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/correction/CorrectionHistoryTable.java
@@ -19,7 +19,7 @@ import com.kelseyde.calvin.tables.tt.TranspositionTable;
  */
 public abstract class CorrectionHistoryTable {
 
-    public static final int SCALE = 256;
+    public static final int SCALE = 512;
     protected static final int MAX = SCALE * 32;
 
     /**


### PR DESCRIPTION
```
Elo   | 8.65 +- 5.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 4018 W: 958 L: 858 D: 2202
Penta | [22, 463, 946, 549, 29]
```
https://kelseyde.pythonanywhere.com/test/338/

bench: 4582830