### PR TITLE
Decrease corrhist scale again

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -848,5 +848,4 @@ public class Searcher implements Search {
                 (ttEntry.flag() == HashFlag.UPPER && ttEntry.score() <= rawStaticEval));
     }
 
-
 }

--- a/src/main/java/com/kelseyde/calvin/tables/correction/CorrectionHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/correction/CorrectionHistoryTable.java
@@ -19,7 +19,7 @@ import com.kelseyde.calvin.tables.tt.TranspositionTable;
  */
 public abstract class CorrectionHistoryTable {
 
-    public static final int SCALE = 128;
+    public static final int SCALE = 64;
     protected static final int MAX = SCALE * 32;
 
     /**


### PR DESCRIPTION
```
Elo   | 3.08 +- 2.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.30 (-2.20, 2.20) [0.00, 5.00]
Games | N: 17510 W: 4106 L: 3951 D: 9453
Penta | [115, 2035, 4305, 2180, 120]
```
https://kelseyde.pythonanywhere.com/test/339/

bench 4716872