### PR TITLE
Prior countermove bonus

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
@@ -72,9 +72,9 @@ public class SearchHistory {
         quietHistoryTable.update(quietMove, piece, depth, white, good);
         for (int prevPly : config.contHistPlies()) {
             SearchStackEntry prevEntry = ss.get(ply - prevPly);
-            if (prevEntry != null && prevEntry.currentMove != null) {
-                Move prevMove = prevEntry.currentMove;
-                Piece prevPiece = prevEntry.currentPiece;
+            if (prevEntry != null && prevEntry.move != null) {
+                Move prevMove = prevEntry.move;
+                Piece prevPiece = prevEntry.piece;
                 contHistTable.update(prevMove, prevPiece, quietMove, piece, depth, white, good);
             }
         }
@@ -118,18 +118,18 @@ public class SearchHistory {
 
     private int getContCorrHistEntry(SearchStack ss, int ply, boolean white) {
         SearchStackEntry sse = ss.get(ply - 1);
-        if (sse == null || sse.currentMove == null) {
+        if (sse == null || sse.move == null) {
             return 0;
         }
-        return countermoveCorrHistTable.get(white, sse.currentMove, sse.currentPiece);
+        return countermoveCorrHistTable.get(white, sse.move, sse.piece);
     }
 
     private void updateContCorrHistEntry(SearchStack ss, int ply, boolean white, int depth, int score, int staticEval) {
         SearchStackEntry sse = ss.get(ply - 1);
-        if (sse == null || sse.currentMove == null) {
+        if (sse == null || sse.move == null) {
             return;
         }
-        countermoveCorrHistTable.update(sse.currentMove, sse.currentPiece, white, staticEval, score, depth);
+        countermoveCorrHistTable.update(sse.move, sse.piece, white, staticEval, score, depth);
     }
 
     public int getBestMoveStability() {

--- a/src/main/java/com/kelseyde/calvin/search/SearchStack.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchStack.java
@@ -25,8 +25,9 @@ public class SearchStack {
 
     public static class SearchStackEntry {
         public int staticEval;
-        public Move currentMove;
-        public Piece currentPiece;
+        public Move move;
+        public Piece piece;
+        public Piece captured;
         public Move bestMove;
         public Move excludedMove;
         public Move[] quiets;

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -294,17 +294,6 @@ public class Searcher implements Search {
         }
         curr.staticEval = staticEval;
 
-        if (!inCheck
-                && !singularSearch
-                && ply >= 1
-                && prev.move != null
-                && prev.captured == null
-                && Score.isDefined(prev.staticEval)) {
-            int value = 6 * -(staticEval + prev.staticEval);
-            int bonus = Math.max(-64, Math.min(128, value));
-            history.getQuietHistoryTable().update(prev.move, prev.piece, !board.isWhite(), bonus);
-        }
-
         // We are 'improving' if the static eval of the current position is greater than it was on our previous turn.
         // If our position is improving we can be more aggressive in our beta pruning - where the eval is too high - but
         // should be more cautious in our alpha pruning - where the eval is too low.
@@ -598,6 +587,14 @@ public class Searcher implements Search {
             // Update the search history with the information from the current search, to improve future move ordering.
             final int historyDepth = depth + (staticEval <= alpha ? 1 : 0) + (bestScore > beta + 50 ? 1 : 0);
             history.updateHistory(board, bestMove, curr.quiets, curr.captures, board.isWhite(), historyDepth, ply, ss);
+        }
+
+        if (flag == HashFlag.UPPER
+                && ply > 0
+                && prev.move != null
+                && prev.captured == null
+                && !prev.move.isPromotion()) {
+            history.getQuietHistoryTable().update(prev.move, prev.piece, depth, !board.isWhite(), true);
         }
 
         if (!inCheck

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -594,6 +594,9 @@ public class Searcher implements Search {
                 && prev.move != null
                 && prev.captured == null
                 && !prev.move.isPromotion()) {
+            // The current node failed low, which means that the parent node will fail high. If the parent move is quiet
+            // it will receive a quiet history bonus in the parent node - but we give it one here too, which ensures the
+            // best move is updated also during PVS re-searches, hopefully leading to better move ordering.
             history.getQuietHistoryTable().update(prev.move, prev.piece, depth, !board.isWhite(), true);
         }
 

--- a/src/main/java/com/kelseyde/calvin/search/picker/MoveScorer.java
+++ b/src/main/java/com/kelseyde/calvin/search/picker/MoveScorer.java
@@ -106,9 +106,9 @@ public class MoveScorer {
         int contHistScore = 0;
         for (int contHistPly : config.contHistPlies()) {
             SearchStackEntry entry = ss.get(ply - contHistPly);
-            if (entry != null && entry.currentMove != null) {
-                Move prevMove = entry.currentMove;
-                Piece prevPiece = entry.currentPiece;
+            if (entry != null && entry.move != null) {
+                Move prevMove = entry.move;
+                Piece prevPiece = entry.piece;
                 contHistScore += history.getContHistTable().get(prevMove, prevPiece, move, piece, white);
             }
         }

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -26,6 +26,13 @@ public class QuietHistoryTable extends AbstractHistoryTable {
         table[colourIndex][piece.index()][move.to()] = update;
     }
 
+    public void update(Move move, Piece piece, boolean white, int bonus) {
+        int colourIndex = Colour.index(white);
+//        short current = table[colourIndex][piece.index()][move.to()];
+//        //short update = gravity(current, (short) bonus);
+        table[colourIndex][piece.index()][move.to()] += (short) bonus;
+    }
+
     public short get(Move move, Piece piece, boolean white) {
         int colourIndex = Colour.index(white);
         return table[colourIndex][piece.index()][move.to()];

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -28,9 +28,9 @@ public class QuietHistoryTable extends AbstractHistoryTable {
 
     public void update(Move move, Piece piece, boolean white, int bonus) {
         int colourIndex = Colour.index(white);
-//        short current = table[colourIndex][piece.index()][move.to()];
-//        //short update = gravity(current, (short) bonus);
-        table[colourIndex][piece.index()][move.to()] += (short) bonus;
+        short current = table[colourIndex][piece.index()][move.to()];
+        short update = gravity(current, (short) bonus);
+        table[colourIndex][piece.index()][move.to()] = update;
     }
 
     public short get(Move move, Piece piece, boolean white) {

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -26,13 +26,6 @@ public class QuietHistoryTable extends AbstractHistoryTable {
         table[colourIndex][piece.index()][move.to()] = update;
     }
 
-    public void update(Move move, Piece piece, boolean white, int bonus) {
-        int colourIndex = Colour.index(white);
-        short current = table[colourIndex][piece.index()][move.to()];
-        short update = gravity(current, (short) bonus);
-        table[colourIndex][piece.index()][move.to()] = update;
-    }
-
     public short get(Move move, Piece piece, boolean white) {
         int colourIndex = Colour.index(white);
         return table[colourIndex][piece.index()][move.to()];

--- a/src/test/java/com/kelseyde/calvin/tables/ContHistTableTest.java
+++ b/src/test/java/com/kelseyde/calvin/tables/ContHistTableTest.java
@@ -53,12 +53,12 @@ public class ContHistTableTest {
         SearchStack ss = new SearchStack();
         Move prevMove = Move.fromUCI("e2e4");
         Piece prevPiece = Piece.PAWN;
-        ss.get(0).currentMove = prevMove;
-        ss.get(0).currentPiece = prevPiece;
+        ss.get(0).move = prevMove;
+        ss.get(0).piece = prevPiece;
         int depth = 8;
         Move currMove = Move.fromUCI("d5e4");
         Piece currPiece = Piece.PAWN;
-        contHistTable.update(ss.get(0).currentMove, ss.get(0).currentPiece, currMove, currPiece, depth, true, true);
+        contHistTable.update(ss.get(0).move, ss.get(0).piece, currMove, currPiece, depth, true, true);
         assertEquals(1200, contHistTable.get(prevMove, prevPiece, currMove, currPiece, true));
     }
 


### PR DESCRIPTION
```
Elo   | 6.29 +- 4.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 5912 W: 1457 L: 1350 D: 3105
Penta | [32, 673, 1455, 748, 48]
```
https://kelseyde.pythonanywhere.com/test/429/

bench 5200344