### PR TITLE
Compress TT entry to 12 bytes

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
@@ -68,9 +68,7 @@ public class ParallelSearcher implements Search {
                     .map(searcher -> initThread(searcher, timeControl))
                     .toList();
 
-            SearchResult result = selectResult(threads).get();
-            tt.incrementAge();
-            return result;
+            return selectResult(threads).get();
         } catch (Exception e) {
             System.out.println("info error " + e);
             // In case of an error, return a random legal move to avoid crashing the engine

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -268,9 +268,9 @@ public class Searcher implements Search {
         // Static Evaluation
         // Obtain a static evaluation of the current board state. In leaf nodes, this is the final score used in search.
         // In non-leaf nodes, this is used as a guide for several heuristics, such as extensions, reductions and pruning.
-        int rawStaticEval = Integer.MIN_VALUE;
-        int uncorrectedStaticEval = Integer.MIN_VALUE;
-        int staticEval = Integer.MIN_VALUE;
+        int rawStaticEval = Score.MIN;
+        int uncorrectedStaticEval = Score.MIN;
+        int staticEval = Score.MIN;
 
         if (singularSearch) {
             // In singular search, since we are in the same node, we can re-use the static eval on the stack.
@@ -658,8 +658,8 @@ public class Searcher implements Search {
         MoveFilter filter;
 
         // Re-use cached static eval if available. Don't compute static eval while in check.
-        int rawStaticEval = Integer.MIN_VALUE;
-        int staticEval = Integer.MIN_VALUE;
+        int rawStaticEval = Score.MIN;
+        int staticEval = Score.MIN;
 
         if (inCheck) {
             // If we are in check, we need to generate 'all' legal moves that evade check, not just captures. Otherwise,
@@ -824,13 +824,13 @@ public class Searcher implements Search {
      * improving. If we were in check 2 plies ago, check 4 plies ago. If we were in check 4 plies ago, return true.
      */
     private boolean isImproving(int ply, int staticEval) {
-        if (staticEval == Integer.MIN_VALUE) return false;
+        if (staticEval == Score.MIN) return false;
         if (ply < 2) return false;
         int lastEval = ss.get(ply - 2).staticEval;
-        if (lastEval == Integer.MIN_VALUE) {
+        if (lastEval == Score.MIN) {
             if (ply < 4) return false;
             lastEval = ss.get(ply - 4).staticEval;
-            if (lastEval == Integer.MIN_VALUE) {
+            if (lastEval == Score.MIN) {
                 return true;
             }
         }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -268,9 +268,9 @@ public class Searcher implements Search {
         // Static Evaluation
         // Obtain a static evaluation of the current board state. In leaf nodes, this is the final score used in search.
         // In non-leaf nodes, this is used as a guide for several heuristics, such as extensions, reductions and pruning.
-        int rawStaticEval = Score.MIN;
-        int uncorrectedStaticEval = Score.MIN;
-        int staticEval = Score.MIN;
+        int rawStaticEval = Integer.MIN_VALUE;
+        int uncorrectedStaticEval = Integer.MIN_VALUE;
+        int staticEval = Integer.MIN_VALUE;
 
         if (singularSearch) {
             // In singular search, since we are in the same node, we can re-use the static eval on the stack.
@@ -658,8 +658,8 @@ public class Searcher implements Search {
         MoveFilter filter;
 
         // Re-use cached static eval if available. Don't compute static eval while in check.
-        int rawStaticEval = Score.MIN;
-        int staticEval = Score.MIN;
+        int rawStaticEval = Integer.MIN_VALUE;
+        int staticEval = Integer.MIN_VALUE;
 
         if (inCheck) {
             // If we are in check, we need to generate 'all' legal moves that evade check, not just captures. Otherwise,
@@ -824,13 +824,13 @@ public class Searcher implements Search {
      * improving. If we were in check 2 plies ago, check 4 plies ago. If we were in check 4 plies ago, return true.
      */
     private boolean isImproving(int ply, int staticEval) {
-        if (staticEval == Score.MIN) return false;
+        if (staticEval == Integer.MIN_VALUE) return false;
         if (ply < 2) return false;
         int lastEval = ss.get(ply - 2).staticEval;
-        if (lastEval == Score.MIN) {
+        if (lastEval == Integer.MIN_VALUE) {
             if (ply < 4) return false;
             lastEval = ss.get(ply - 4).staticEval;
-            if (lastEval == Score.MIN) {
+            if (lastEval == Integer.MIN_VALUE) {
                 return true;
             }
         }

--- a/src/main/java/com/kelseyde/calvin/tables/tt/HashEntry.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/HashEntry.java
@@ -17,7 +17,9 @@ public record HashEntry(Move move, int score, int staticEval, int flag, int dept
         final int score      = Value.getScore(value);
         final int flag       = Key.getFlag(key);
         final int depth      = Key.getDepth(key);
-        final int staticEval = Key.getStaticEval(key);
+        int staticEval       = Key.getStaticEval(key);
+        if (staticEval == Short.MIN_VALUE)
+            staticEval = Integer.MIN_VALUE;
         final boolean pv     = Key.isPv(key);
         return new HashEntry(move, score, staticEval, flag, depth, pv);
     }
@@ -51,6 +53,8 @@ public record HashEntry(Move move, int score, int staticEval, int flag, int dept
         }
 
         public static long of(long zobristKey, int depth, int staticEval, int flag, boolean pv) {
+            if (staticEval == Integer.MIN_VALUE)
+                staticEval = Short.MIN_VALUE;
             depth = Math.min(depth, 255);
             long pvBit = pv ? 1L : 0L;
             return (zobristKey & ZOBRIST_PART_MASK) |

--- a/src/main/java/com/kelseyde/calvin/tables/tt/HashEntry.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/HashEntry.java
@@ -6,90 +6,88 @@ import com.kelseyde.calvin.board.Move;
  * Entry in the {@link TranspositionTable}.
  * </p>
  * Records the move, score, static evaluation, flag, and depth of a position that has been searched. When stored in the
- * table, this information is packed into two 64-bit longs: a key and a value. The encoding scheme is as follows:
- * - Key: 0-31 (zobrist key), 32-47 (age), 48-63 (static eval)
- * - Value: 0-11 (depth), 12-15 (flag), 16-31 (move), 32-63 (score)
+ * table, this information is packed into a 64-bit long (key) and a 32-bit integer (value). The encoding scheme is as follows:
+ * - Key: 0-31 (zobrist key), 32-39 (depth), 40-55 (static eval), 56-57 (flag), 58 (pv), 59-63 (unused)
+ * - Value: 0-15 (score), 16-31 (move)
  */
 public record HashEntry(Move move, int score, int staticEval, int flag, int depth, boolean pv) {
 
-    public static HashEntry of(long key, long value) {
-        final Move move       = Value.getMove(value);
-        final int flag        = Value.getFlag(value);
-        final int depth       = Value.getDepth(value);
-        final int score       = Value.getScore(value);
-        final int staticEval  = Key.getStaticEval(key);
-        final boolean pv      = Value.isPv(value);
+    public static HashEntry of(long key, int value) {
+        final Move move      = Value.getMove(value);
+        final int score      = Value.getScore(value);
+        final int flag       = Key.getFlag(key);
+        final int depth      = Key.getDepth(key);
+        final int staticEval = Key.getStaticEval(key);
+        final boolean pv     = Key.isPv(key);
         return new HashEntry(move, score, staticEval, flag, depth, pv);
     }
 
     public static class Key {
 
-        private static final long STATIC_EVAL_MASK    = 0xffff000000000000L;
-        private static final long AGE_MASK            = 0x0000ffff00000000L;
         private static final long ZOBRIST_PART_MASK   = 0x00000000ffffffffL;
+        private static final long DEPTH_MASK          = 0x000000ff00000000L;
+        private static final long STATIC_EVAL_MASK    = 0x00ffff0000000000L;
+        private static final long FLAG_MASK           = 0x0300000000000000L;
+        private static final long PV_MASK             = 0x0400000000000000L;
 
         public static long getZobristPart(long key) {
             return key & ZOBRIST_PART_MASK;
         }
 
-        public static int getAge(long key) {
-            return (int) ((key & AGE_MASK) >>> 32);
-        }
-
-        public static long setAge(long key, int age) {
-            return (key & ~AGE_MASK) | ((long) age << 32);
+        public static int getDepth(long key) {
+            return (int) ((key & DEPTH_MASK) >>> 32);
         }
 
         public static int getStaticEval(long key) {
-            return (short) ((key & STATIC_EVAL_MASK) >>> 48);
+            return (short) ((key & STATIC_EVAL_MASK) >>> 40);
         }
 
-        public static long of(long zobristKey, int staticEval, int age) {
-            return (zobristKey & ZOBRIST_PART_MASK) | ((long) age << 32) | ((long) (staticEval & 0xFFFF) << 48);
+        public static int getFlag(long key) {
+            return (int) ((key & FLAG_MASK) >>> 56);
         }
 
+        public static boolean isPv(long key) {
+            return ((key & PV_MASK) >>> 58) == 1;
+        }
+
+        public static long of(long zobristKey, int depth, int staticEval, int flag, boolean pv) {
+            depth = Math.min(depth, 255);
+            long pvBit = pv ? 1L : 0L;
+            return (zobristKey & ZOBRIST_PART_MASK) |
+                    ((long) depth << 32) |
+                    ((long) (staticEval & 0xFFFF) << 40) |
+                    ((long) (flag & 0x3) << 56) |
+                    (pvBit << 58);
+        }
     }
 
     public static class Value {
 
-        private static final long SCORE_MASK    = 0xffffffff00000000L;
-        private static final long MOVE_MASK     = 0x00000000ffff0000L;
-        private static final long FLAG_MASK     = 0x000000000000f000L;
-        private static final long PV_MASK       = 0x0000000000000f00L;
-        private static final long DEPTH_MASK    = 0x00000000000000ffL;
+        private static final int SCORE_MASK = 0x0000ffff;
+        private static final int MOVE_MASK  = 0xffff0000;
 
-        public static int getScore(long value) {
-            return (int) ((value & SCORE_MASK) >>> 32);
+        public static int getScore(int value) {
+            return (short) (value & SCORE_MASK);
         }
 
-        public static long setScore(long value, int score) {
-            return (value & ~SCORE_MASK) | (long) score << 32;
+        public static int setScore(int value, int score) {
+            return (value & MOVE_MASK) | (score & SCORE_MASK);
         }
 
-        public static Move getMove(long value) {
-            long move = (value & MOVE_MASK) >>> 16;
+        public static Move getMove(int value) {
+            int move = (value & MOVE_MASK) >>> 16;
             return move > 0 ? new Move((short) move) : null;
         }
 
-        public static int getFlag(long value) {
-            return (int) (value & FLAG_MASK) >>> 12;
+        public static int of(int score, Move move) {
+            int moveValue = move != null ? move.value() : 0;
+            return (moveValue << 16) | (score & 0xFFFF);
         }
-
-        public static int getDepth(long value) {
-            return (int) (value & DEPTH_MASK);
-        }
-
-        public static boolean isPv(long value) {
-            return (value & PV_MASK) >>> 8 == 1;
-        }
-
-        public static long of(int score, Move move, int flag, int depth, boolean pv) {
-            depth = Math.min(depth, 255);
-            long pvFlag = pv ? 1 : 0;
-            long moveValue = move != null ? move.value() : 0;
-            return (long) score << 32 | moveValue << 16 | (long) flag << 12 | pvFlag << 8 | depth;
-        }
-
     }
 
+    private static void assertRange(int value, int min, int max) {
+        if (value < min || value > max) {
+            throw new IllegalArgumentException("Value out of range: " + value);
+        }
+    }
 }

--- a/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/TranspositionTable.java
@@ -19,12 +19,11 @@ import java.util.stream.IntStream;
 public class TranspositionTable {
 
     private static final int BUCKET_SIZE = 4;
-    private static final int ENTRY_SIZE_BYTES = 16;
+    private static final int ENTRY_SIZE_BYTES = 12;
 
     private long[] keys;
-    private long[] values;
+    private int[] values;
     private int size;
-    private int age;
     private int tries;
     private int hits;
 
@@ -34,10 +33,9 @@ public class TranspositionTable {
     public TranspositionTable(int tableSizeMb) {
         this.size = (tableSizeMb * 1024 * 1024) / ENTRY_SIZE_BYTES;
         this.keys = new long[size];
-        this.values = new long[size];
+        this.values = new int[size];
         this.tries = 0;
         this.hits = 0;
-        this.age = 0;
     }
 
     /**
@@ -50,9 +48,8 @@ public class TranspositionTable {
             long storedKey = keys[index + i];
             if (storedKey != 0 && HashEntry.Key.getZobristPart(storedKey) == HashEntry.Key.getZobristPart(key)) {
                 hits++;
-                storedKey = HashEntry.Key.setAge(storedKey, age);
                 keys[index + i] = storedKey;
-                long storedValue = values[index + i];
+                int storedValue = values[index + i];
                 int score = HashEntry.Value.getScore(storedValue);
                 if (Score.isMate(score)) {
                     score = retrieveMateScore(score, ply);
@@ -105,15 +102,15 @@ public class TranspositionTable {
                 break;
             }
 
-            long storedValue = values[i];
+            int storedValue = values[i];
 
-            int storedFlag = HashEntry.Value.getFlag(storedValue);
+            int storedFlag = HashEntry.Key.getFlag(storedKey);
             if (storedFlag == HashFlag.NONE) {
                 replacedIndex = i;
                 break;
             }
 
-            int storedDepth = HashEntry.Value.getDepth(values[i]);
+            int storedDepth = HashEntry.Key.getDepth(storedKey);
             // Then, if the stored entry matches the zobrist key and the depth is >= the stored depth, replace it.
             // If the depth is < the store depth, don't replace it and exit (although this should never happen).
             if (HashEntry.Key.getZobristPart(storedKey) == HashEntry.Key.getZobristPart(key)) {
@@ -130,12 +127,6 @@ public class TranspositionTable {
                 }
             }
 
-            // Next, prefer to replace entries from earlier on in the game, since they are now less likely to be relevant.
-            if (age > HashEntry.Key.getAge(storedKey)) {
-                replacedByAge = true;
-                replacedIndex = i;
-            }
-
             // Finally, just replace the entry with the shallowest search depth.
             if (!replacedByAge && storedDepth < minDepth) {
                 minDepth = storedDepth;
@@ -146,8 +137,8 @@ public class TranspositionTable {
 
         // Store the new entry in the table at the chosen index.
         if (replacedIndex != -1) {
-            keys[replacedIndex] = HashEntry.Key.of(key, staticEval, age);
-            values[replacedIndex] = HashEntry.Value.of(score, move, flag, depth, pv);
+            keys[replacedIndex] = HashEntry.Key.of(key, depth, staticEval, flag, pv);
+            values[replacedIndex] = HashEntry.Value.of(score, move);
         }
     }
 
@@ -161,20 +152,12 @@ public class TranspositionTable {
                 .count();
     }
 
-    /**
-     * Increments the age counter for the transposition table.
-     */
-    public void incrementAge() {
-        this.age++;
-    }
-
     public void resize(int tableSizeMb) {
         this.size = (tableSizeMb * 1024 * 1024) / ENTRY_SIZE_BYTES;
         this.keys = new long[size];
-        this.values = new long[size];
+        this.values = new int[size];
         this.tries = 0;
         this.hits = 0;
-        this.age = 0;
     }
 
     /**
@@ -183,9 +166,8 @@ public class TranspositionTable {
     public void clear() {
         this.tries = 0;
         this.hits = 0;
-        this.age = 0;
         this.keys = new long[size];
-        this.values = new long[size];
+        this.values = new int[size];
     }
 
     /**


### PR DESCRIPTION
```
Elo   | 5.38 +- 4.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 7236 W: 1764 L: 1652 D: 3820
Penta | [47, 810, 1801, 904, 56]
```
https://kelseyde.pythonanywhere.com/test/450/

bench 5279706