### PR TITLE
Scale futility margin based on move count

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -38,6 +38,7 @@ public class EngineConfig {
     private final Tunable fpMargin               = new Tunable("FpMargin", 137, 0, 500, 25);
     private final Tunable fpScale                = new Tunable("FpScale", 82, 0, 100, 5);
     private final Tunable fpHistDivisor          = new Tunable("FpHistDivisor", 103, 1, 1000, 25);
+    private final Tunable fpMoveMultiplier       = new Tunable("FpMoveMultiplier", 4, 0, 10, 1);
     private final Tunable seeMaxDepth            = new Tunable("SeeMaxDepth", 10, 6, 12, 1);
     private final Tunable seeQuietMargin         = new Tunable("SeeQuietMargin", -40, -250, -10, 25);
     private final Tunable seeNoisyMargin         = new Tunable("SeeNoisyMargin", -24, -250, -10, 25);
@@ -126,7 +127,7 @@ public class EngineConfig {
                 seeHistoryDivisor, timeFactor, incrementFactor, softTimeFactor, hardTimeFactor, softTimeScaleMin,
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
-                seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor
+                seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier
         );
     }
 
@@ -262,6 +263,10 @@ public class EngineConfig {
 
     public int fpHistDivisor() {
         return fpHistDivisor.value;
+    }
+
+    public int fpMoveMultiplier() {
+        return fpMoveMultiplier.value;
     }
 
     public int seeMaxDepth() {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -881,7 +881,7 @@ public class Searcher implements Search {
         return config.fpMargin()
                 + depth * config.fpScale()
                 + (historyScore / config.fpHistDivisor())
-                - searchedMoves * 4;
+                - searchedMoves * config.fpMoveMultiplier();
     }
 
     private int seeThreshold(int depth, int historyScore, boolean isQuiet) {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -431,7 +431,7 @@ public class Searcher implements Search {
 
             // Futility Pruning
             // Skip quiet moves when the static evaluation + some margin is still below alpha.
-            final int futilityMargin = futilityMargin(reducedDepth, historyScore);
+            final int futilityMargin = futilityMargin(reducedDepth, historyScore, searchedMoves);
             if (!pvNode
                     && !rootNode
                     && isQuiet
@@ -877,10 +877,11 @@ public class Searcher implements Search {
         history.clear();
     }
 
-    private int futilityMargin(int depth, int historyScore) {
+    private int futilityMargin(int depth, int historyScore, int searchedMoves) {
         return config.fpMargin()
                 + depth * config.fpScale()
-                + (historyScore / config.fpHistDivisor());
+                + (historyScore / config.fpHistDivisor())
+                - searchedMoves * 4;
     }
 
     private int seeThreshold(int depth, int historyScore, boolean isQuiet) {


### PR DESCRIPTION
```
Elo   | 2.81 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 20736 W: 5062 L: 4894 D: 10780
Penta | [155, 2435, 5045, 2553, 180]
```
https://kelseyde.pythonanywhere.com/test/457/

bench 5756474