### PR TITLE
Return fail medium best score for Q-search fail-high

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -757,6 +757,10 @@ public class Searcher implements Search {
             return -Score.MATE + ply;
         }
 
+        if (bestScore >= beta && !Score.isMate(bestScore) && !Score.isMate(beta)) {
+            bestScore = (bestScore + beta) / 2;
+        }
+
         if (!hardLimitReached()) {
             tt.put(board.key(), flag, 0, ply, bestMove, rawStaticEval, bestScore, ttPv);
         }


### PR DESCRIPTION
```
Elo   | 5.11 +- 4.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 7820 W: 1973 L: 1858 D: 3989
Penta | [56, 873, 1950, 962, 69]
```
https://kelseyde.pythonanywhere.com/test/464/

bench 5945241