### PR TITLE
Revert "Compress TT entry to 12 bytes"

### DIFF
--- a/header.sh
+++ b/header.sh
@@ -1,17 +1,4 @@
 #!/bin/sh
-
-# Taken from https://web.archive.org/web/20240813210415/https://coderwall.com/p/ssuaxa/how-to-make-a-jar-file-linux-executable
-
-MYSELF=`which "$0" 2>/dev/null`
-
-[ $? -gt 0 -a -f "$0" ] && MYSELF="./$0"
-
-java=java
-
-if test -n "$JAVA_HOME"; then
-    java="$JAVA_HOME/bin/java"
-fi
-
-exec "$java" --add-modules=jdk.incubator.vector -XX:+UseParallelGC $java_args -jar $MYSELF "$@"
+exec java --add-modules=jdk.incubator.vector -XX:+UseParallelGC -cp "$0" com.kelseyde.calvin.Application "$@"
 
 exit 1

--- a/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/ParallelSearcher.java
@@ -68,7 +68,9 @@ public class ParallelSearcher implements Search {
                     .map(searcher -> initThread(searcher, timeControl))
                     .toList();
 
-            return selectResult(threads).get();
+            SearchResult result = selectResult(threads).get();
+            tt.incrementAge();
+            return result;
         } catch (Exception e) {
             System.out.println("info error " + e);
             // In case of an error, return a random legal move to avoid crashing the engine

--- a/src/main/java/com/kelseyde/calvin/tables/tt/HashEntry.java
+++ b/src/main/java/com/kelseyde/calvin/tables/tt/HashEntry.java
@@ -6,92 +6,90 @@ import com.kelseyde.calvin.board.Move;
  * Entry in the {@link TranspositionTable}.
  * </p>
  * Records the move, score, static evaluation, flag, and depth of a position that has been searched. When stored in the
- * table, this information is packed into a 64-bit long (key) and a 32-bit integer (value). The encoding scheme is as follows:
- * - Key: 0-31 (zobrist key), 32-39 (depth), 40-55 (static eval), 56-57 (flag), 58 (pv), 59-63 (unused)
- * - Value: 0-15 (score), 16-31 (move)
+ * table, this information is packed into two 64-bit longs: a key and a value. The encoding scheme is as follows:
+ * - Key: 0-31 (zobrist key), 32-47 (age), 48-63 (static eval)
+ * - Value: 0-11 (depth), 12-15 (flag), 16-31 (move), 32-63 (score)
  */
 public record HashEntry(Move move, int score, int staticEval, int flag, int depth, boolean pv) {
 
-    public static HashEntry of(long key, int value) {
-        final Move move      = Value.getMove(value);
-        final int score      = Value.getScore(value);
-        final int flag       = Key.getFlag(key);
-        final int depth      = Key.getDepth(key);
-        int staticEval       = Key.getStaticEval(key);
-        if (staticEval == Short.MIN_VALUE)
-            staticEval = Integer.MIN_VALUE;
-        final boolean pv     = Key.isPv(key);
+    public static HashEntry of(long key, long value) {
+        final Move move       = Value.getMove(value);
+        final int flag        = Value.getFlag(value);
+        final int depth       = Value.getDepth(value);
+        final int score       = Value.getScore(value);
+        final int staticEval  = Key.getStaticEval(key);
+        final boolean pv      = Value.isPv(value);
         return new HashEntry(move, score, staticEval, flag, depth, pv);
     }
 
     public static class Key {
 
+        private static final long STATIC_EVAL_MASK    = 0xffff000000000000L;
+        private static final long AGE_MASK            = 0x0000ffff00000000L;
         private static final long ZOBRIST_PART_MASK   = 0x00000000ffffffffL;
-        private static final long DEPTH_MASK          = 0x000000ff00000000L;
-        private static final long STATIC_EVAL_MASK    = 0x00ffff0000000000L;
-        private static final long FLAG_MASK           = 0x0300000000000000L;
-        private static final long PV_MASK             = 0x0400000000000000L;
 
         public static long getZobristPart(long key) {
             return key & ZOBRIST_PART_MASK;
         }
 
-        public static int getDepth(long key) {
-            return (int) ((key & DEPTH_MASK) >>> 32);
+        public static int getAge(long key) {
+            return (int) ((key & AGE_MASK) >>> 32);
+        }
+
+        public static long setAge(long key, int age) {
+            return (key & ~AGE_MASK) | ((long) age << 32);
         }
 
         public static int getStaticEval(long key) {
-            return (short) ((key & STATIC_EVAL_MASK) >>> 40);
+            return (short) ((key & STATIC_EVAL_MASK) >>> 48);
         }
 
-        public static int getFlag(long key) {
-            return (int) ((key & FLAG_MASK) >>> 56);
+        public static long of(long zobristKey, int staticEval, int age) {
+            return (zobristKey & ZOBRIST_PART_MASK) | ((long) age << 32) | ((long) (staticEval & 0xFFFF) << 48);
         }
 
-        public static boolean isPv(long key) {
-            return ((key & PV_MASK) >>> 58) == 1;
-        }
-
-        public static long of(long zobristKey, int depth, int staticEval, int flag, boolean pv) {
-            if (staticEval == Integer.MIN_VALUE)
-                staticEval = Short.MIN_VALUE;
-            depth = Math.min(depth, 255);
-            long pvBit = pv ? 1L : 0L;
-            return (zobristKey & ZOBRIST_PART_MASK) |
-                    ((long) depth << 32) |
-                    ((long) (staticEval & 0xFFFF) << 40) |
-                    ((long) (flag & 0x3) << 56) |
-                    (pvBit << 58);
-        }
     }
 
     public static class Value {
 
-        private static final int SCORE_MASK = 0x0000ffff;
-        private static final int MOVE_MASK  = 0xffff0000;
+        private static final long SCORE_MASK    = 0xffffffff00000000L;
+        private static final long MOVE_MASK     = 0x00000000ffff0000L;
+        private static final long FLAG_MASK     = 0x000000000000f000L;
+        private static final long PV_MASK       = 0x0000000000000f00L;
+        private static final long DEPTH_MASK    = 0x00000000000000ffL;
 
-        public static int getScore(int value) {
-            return (short) (value & SCORE_MASK);
+        public static int getScore(long value) {
+            return (int) ((value & SCORE_MASK) >>> 32);
         }
 
-        public static int setScore(int value, int score) {
-            return (value & MOVE_MASK) | (score & SCORE_MASK);
+        public static long setScore(long value, int score) {
+            return (value & ~SCORE_MASK) | (long) score << 32;
         }
 
-        public static Move getMove(int value) {
-            int move = (value & MOVE_MASK) >>> 16;
+        public static Move getMove(long value) {
+            long move = (value & MOVE_MASK) >>> 16;
             return move > 0 ? new Move((short) move) : null;
         }
 
-        public static int of(int score, Move move) {
-            int moveValue = move != null ? move.value() : 0;
-            return (moveValue << 16) | (score & 0xFFFF);
+        public static int getFlag(long value) {
+            return (int) (value & FLAG_MASK) >>> 12;
         }
+
+        public static int getDepth(long value) {
+            return (int) (value & DEPTH_MASK);
+        }
+
+        public static boolean isPv(long value) {
+            return (value & PV_MASK) >>> 8 == 1;
+        }
+
+        public static long of(int score, Move move, int flag, int depth, boolean pv) {
+            depth = Math.min(depth, 255);
+            long pvFlag = pv ? 1 : 0;
+            long moveValue = move != null ? move.value() : 0;
+            return (long) score << 32 | moveValue << 16 | (long) flag << 12 | pvFlag << 8 | depth;
+        }
+
     }
 
-    private static void assertRange(int value, int min, int max) {
-        if (value < min || value > max) {
-            throw new IllegalArgumentException("Value out of range: " + value);
-        }
-    }
 }

--- a/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
+++ b/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
@@ -3,7 +3,6 @@ package com.kelseyde.calvin.tables;
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.board.Move;
 import com.kelseyde.calvin.board.Piece;
-import com.kelseyde.calvin.search.Score;
 import com.kelseyde.calvin.tables.tt.HashEntry;
 import com.kelseyde.calvin.tables.tt.HashFlag;
 import com.kelseyde.calvin.tables.tt.TranspositionTable;
@@ -53,7 +52,7 @@ public class TranspositionTableTest {
         Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
         long zobristKey = board.getState().getKey();
         int depth = 1;
-        int score = Score.MATE;
+        int score = 1000000;
         int flag = HashFlag.UPPER;
         Move move = Move.fromUCI("e2e4");
         assertEntry(zobristKey, score, move, flag, depth, true);
@@ -64,7 +63,7 @@ public class TranspositionTableTest {
         Board board = FEN.toBoard("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23");
         long zobristKey = board.getState().getKey();
         int depth = 1;
-        int score = -Score.MATE;
+        int score = -1000000;
         int flag = HashFlag.UPPER;
         Move move = Move.fromUCI("e2e4");
         assertEntry(zobristKey, score, move, flag, depth, false);
@@ -132,15 +131,15 @@ public class TranspositionTableTest {
 
         board.makeMove(TestUtils.getLegalMove(board, "g8", "f6"));
         flag = HashFlag.LOWER;
-        eval = -Score.MATE;
+        eval = 1000000;
         depth = 10;
         table.put(board.getState().getKey(), flag, depth, ply + 2, null, 0,  eval, true);
 
         entry = table.get(board.getState().getKey(), ply);
         Assertions.assertNotNull(entry);
         Assertions.assertEquals(flag, entry.flag());
-        Assertions.assertNull(entry.move());
-        Assertions.assertEquals(eval + 2, entry.score());
+        Assertions.assertEquals(null, entry.move());
+        Assertions.assertEquals(eval - 2, entry.score());
         Assertions.assertEquals(depth, entry.depth());
     }
 
@@ -210,13 +209,13 @@ public class TranspositionTableTest {
         int plyRemaining = 10;
         int plyFromRoot = 0;
 
-        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0, Score.MATE, true);
+        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  1000000, true);
 
-        Assertions.assertEquals(Score.MATE, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(1000000, table.get(board.getState().getKey(), 0).score());
 
-        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0, -Score.MATE, false);
+        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0,  -1000000, false);
 
-        Assertions.assertEquals(-Score.MATE, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(-1000000, table.get(board.getState().getKey(), 0).score());
 
     }
 
@@ -228,13 +227,13 @@ public class TranspositionTableTest {
         int plyRemaining = 10;
         int plyFromRoot = 1;
 
-        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  Score.MATE, true);
+        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  1000000, true);
 
-        Assertions.assertEquals(Score.MATE - 1, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(999999, table.get(board.getState().getKey(), 0).score());
 
-        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0,  -Score.MATE, false);
+        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0,  -1000000, false);
 
-        Assertions.assertEquals(-Score.MATE + 1, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(-999999, table.get(board.getState().getKey(), 0).score());
 
     }
 
@@ -244,18 +243,18 @@ public class TranspositionTableTest {
         long zobrist = board.getState().getKey();
         int flag = HashFlag.EXACT;
         Move bestMove = Move.fromUCI("e7e8b");
-        int score = Score.MATE;
+        int eval = 1000000;
         int plyRemaining = 10;
         int plyFromRoot = 5;
 
-        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  score, true);
+        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  eval, true);
 
-        Assertions.assertEquals(Score.MATE, table.get(zobrist, 5).score());
-        Assertions.assertEquals(Score.MATE - 1, table.get(zobrist, 4).score());
-        Assertions.assertEquals(Score.MATE - 2, table.get(zobrist, 3).score());
-        Assertions.assertEquals(Score.MATE - 3, table.get(zobrist, 2).score());
-        Assertions.assertEquals(Score.MATE - 4, table.get(zobrist, 1).score());
-        Assertions.assertEquals(Score.MATE - 5, table.get(zobrist, 0).score());
+        Assertions.assertEquals(1000000, table.get(zobrist, 5).score());
+        Assertions.assertEquals(999999, table.get(zobrist, 4).score());
+        Assertions.assertEquals(999998, table.get(zobrist, 3).score());
+        Assertions.assertEquals(999997, table.get(zobrist, 2).score());
+        Assertions.assertEquals(999996, table.get(zobrist, 1).score());
+        Assertions.assertEquals(999995, table.get(zobrist, 0).score());
     }
 
     @Test
@@ -342,8 +341,8 @@ public class TranspositionTableTest {
     }
 
     private void assertEntry(long zobrist, int score, Move move, int flag, int depth, boolean pv) {
-        long key = HashEntry.Key.of(zobrist, depth, 0, flag, pv);
-        int value = HashEntry.Value.of(score, move);
+        long key = HashEntry.Key.of(zobrist, 0, 0);
+        long value = HashEntry.Value.of(score, move, flag, depth, pv);
         HashEntry entry = HashEntry.of(key, value);
         Assertions.assertEquals(depth, entry.depth());
         Assertions.assertEquals(score, entry.score());


### PR DESCRIPTION
Reverts kelseyde/calvin-chess-engine#335 but also prevents the crashes that have been happening since that was merged. Unfortunately haven't figured out the root cause yet.

```
Elo   | -3.85 +- 3.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.23 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 11992 W: 2803 L: 2936 D: 6253
Penta | [106, 1499, 2886, 1432, 73]
```

https://kelseyde.pythonanywhere.com/test/472/

bench 6232928