### PR TITLE
Reduce more when previous node fails high

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -62,6 +62,9 @@ public class EngineConfig {
     private final Tunable lmrCutNode             = new Tunable("LmrCutNode", 2106, 0, 3072, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 94, 0, 2048, 150);
     private final Tunable lmrFutile              = new Tunable("LmrFutile", 1012, 0, 2048, 150);
+    private final Tunable lmrFailHighCountLimit  = new Tunable("LmrCutoffCountLimit", 3, 2, 5, 1);
+    private final Tunable lmrFailHighCountBase   = new Tunable("LmrCutoffCountBase", 896, 0, 1024, 150);
+    private final Tunable lmrFailHighCountScale  = new Tunable("LmrCutoffCountScale", 64, 16, 128, 16);
     private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3037, 1536, 6144, 1000);
     private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3122, 1536, 6144, 1000);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
@@ -131,7 +134,7 @@ public class EngineConfig {
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
-                lmpImpBase, lmpImpScale
+                lmpImpBase, lmpImpScale, lmrFailHighCountBase, lmrFailHighCountScale, lmrFailHighCountLimit
         );
     }
 
@@ -363,6 +366,18 @@ public class EngineConfig {
 
     public int lmrFutile() {
         return lmrFutile.value;
+    }
+
+    public int lmrFailHighCountBase() {
+        return lmrFailHighCountBase.value;
+    }
+
+    public int lmrFailHighCountScale() {
+        return lmrFailHighCountScale.value;
+    }
+
+    public int lmrFailHighCountLimit() {
+        return lmrFailHighCountLimit.value;
     }
 
     public int lmrQuietHistoryDiv() {

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -62,9 +62,7 @@ public class EngineConfig {
     private final Tunable lmrCutNode             = new Tunable("LmrCutNode", 2106, 0, 3072, 150);
     private final Tunable lmrNotImproving        = new Tunable("LmrNotImproving", 94, 0, 2048, 150);
     private final Tunable lmrFutile              = new Tunable("LmrFutile", 1012, 0, 2048, 150);
-    private final Tunable lmrFailHighCountLimit  = new Tunable("LmrCutoffCountLimit", 3, 2, 5, 1);
-    private final Tunable lmrFailHighCountBase   = new Tunable("LmrCutoffCountBase", 896, 0, 1024, 150);
-    private final Tunable lmrFailHighCountScale  = new Tunable("LmrCutoffCountScale", 64, 16, 128, 16);
+    private final Tunable lmrFailHighCount       = new Tunable("LmrCutoffCount", 1024, 0, 2048, 150);
     private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3037, 1536, 6144, 1000);
     private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3122, 1536, 6144, 1000);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
@@ -134,7 +132,7 @@ public class EngineConfig {
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
-                lmpImpBase, lmpImpScale, lmrFailHighCountBase, lmrFailHighCountScale, lmrFailHighCountLimit
+                lmpImpBase, lmpImpScale, lmrFailHighCount
         );
     }
 
@@ -368,16 +366,8 @@ public class EngineConfig {
         return lmrFutile.value;
     }
 
-    public int lmrFailHighCountBase() {
-        return lmrFailHighCountBase.value;
-    }
-
-    public int lmrFailHighCountScale() {
-        return lmrFailHighCountScale.value;
-    }
-
-    public int lmrFailHighCountLimit() {
-        return lmrFailHighCountLimit.value;
+    public int lmrFailHighCount() {
+        return lmrFailHighCount.value;
     }
 
     public int lmrQuietHistoryDiv() {

--- a/src/main/java/com/kelseyde/calvin/search/SearchStack.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchStack.java
@@ -5,20 +5,22 @@ import com.kelseyde.calvin.board.Piece;
 
 public class SearchStack {
 
-    private final SearchStackEntry[] stack = new SearchStackEntry[Search.MAX_DEPTH];
+    private static final int STACK_SIZE = Search.MAX_DEPTH + 8;
+
+    private final SearchStackEntry[] stack = new SearchStackEntry[STACK_SIZE];
 
     public SearchStack() {
-        for (int i = 0; i < Search.MAX_DEPTH; i++) {
+        for (int i = 0; i < STACK_SIZE; i++) {
             stack[i] = new SearchStackEntry();
         }
     }
 
     public SearchStackEntry get(int ply) {
-        return ply >= 0 && ply < Search.MAX_DEPTH ? stack[ply] : null;
+        return ply >= 0 && ply < STACK_SIZE ? stack[ply] : null;
     }
 
     public void clear() {
-        for (int i = 0; i < Search.MAX_DEPTH; i++) {
+        for (int i = 0; i < STACK_SIZE; i++) {
             stack[i] = new SearchStackEntry();
         }
     }
@@ -32,6 +34,7 @@ public class SearchStack {
         public Move excludedMove;
         public Move[] quiets;
         public Move[] captures;
+        public int failHighCount;
         public boolean nullMoveAllowed = true;
     }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -215,6 +215,7 @@ public class Searcher implements Search {
         final boolean singularSearch = excludedMove != null;
 
         history.getKillerTable().clear(ply + 1);
+        ss.get(ply + 2).failHighCount = 0;
 
         // Transposition table
         // Check if this node has already been searched before. If so, we can potentially re-use the result of the
@@ -421,6 +422,7 @@ public class Searcher implements Search {
                         + (depth) * config.fpScale()
                         + (historyScore / config.fpHistDivisor());
                 r += staticEval + futilityMargin <= alpha ? config.lmrFutile() : 0;
+                r += !rootNode && prev.failHighCount > config.lmrFailHighCountLimit() ? failHighCountReduction(prev) : 0;
 
                 reduction = Math.max(0, r / 1024);
             }
@@ -571,6 +573,7 @@ public class Searcher implements Search {
                     // If the score is greater than beta, then this position is 'too good' - our opponent won't let us
                     // get here assuming perfect play, and so there's no point searching further.
                     flag = HashFlag.LOWER;
+                    curr.failHighCount++;
                     break;
                 }
             }
@@ -900,6 +903,13 @@ public class Searcher implements Search {
                 config.seeNoisyMargin() * depth * depth;
         threshold -= historyScore / config.seeHistoryDivisor();
         return threshold;
+    }
+
+    private int failHighCountReduction(SearchStackEntry prev) {
+        final int base = config.lmrFailHighCountBase();
+        final int scale = config.lmrFailHighCountScale();
+        final int count = prev.failHighCount;
+        return base + scale * Math.max(count, 8);
     }
 
     private boolean canUseTTScore(HashEntry ttEntry, int rawStaticEval) {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -422,7 +422,7 @@ public class Searcher implements Search {
                         + (depth) * config.fpScale()
                         + (historyScore / config.fpHistDivisor());
                 r += staticEval + futilityMargin <= alpha ? config.lmrFutile() : 0;
-                r += !rootNode && prev.failHighCount > config.lmrFailHighCountLimit() ? failHighCountReduction(prev) : 0;
+                r += !rootNode && prev.failHighCount > 2 ? config.lmrFailHighCount() : 0;
 
                 reduction = Math.max(0, r / 1024);
             }
@@ -903,13 +903,6 @@ public class Searcher implements Search {
                 config.seeNoisyMargin() * depth * depth;
         threshold -= historyScore / config.seeHistoryDivisor();
         return threshold;
-    }
-
-    private int failHighCountReduction(SearchStackEntry prev) {
-        final int base = config.lmrFailHighCountBase();
-        final int scale = config.lmrFailHighCountScale();
-        final int count = prev.failHighCount;
-        return base + scale * Math.max(count, 8);
     }
 
     private boolean canUseTTScore(HashEntry ttEntry, int rawStaticEval) {


### PR DESCRIPTION
```
Elo   | 2.82 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 19608 W: 4710 L: 4551 D: 10347
Penta | [135, 2252, 4862, 2429, 126]
```
https://kelseyde.pythonanywhere.com/test/513/

bench 5046816