### PR TITLE
Hindsight LMR extension

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -85,6 +85,7 @@ public class EngineConfig {
     private final Tunable seReductionDivisor     = new Tunable("SeReductionDivisor", 2, 1, 4, 1);
     private final Tunable seDoubleExtMargin      = new Tunable("SeDoubleExtMargin", 20, 0, 32, 5);
     private final Tunable ttExtensionDepth       = new Tunable("TtExtDepth", 6, 0, 12, 1);
+    private final Tunable hindsightExtLimit      = new Tunable("HindsightExtensionLimit", 3, 2, 5, 1);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
     private final Tunable quietHistMalusMax      = new Tunable("QuietHistMalusMax", 1200, 100, 2000, 100);
@@ -133,7 +134,7 @@ public class EngineConfig {
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
-                lmpImpBase, lmpImpScale, lmrFailHighCount
+                lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit
         );
     }
 
@@ -457,6 +458,10 @@ public class EngineConfig {
 
     public int ttExtensionDepth() {
         return ttExtensionDepth.value;
+    }
+
+    public int hindsightExtLimit() {
+        return hindsightExtLimit.value;
     }
 
     public int quietHistBonusMax() {

--- a/src/main/java/com/kelseyde/calvin/search/SearchStack.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchStack.java
@@ -34,6 +34,7 @@ public class SearchStack {
         public Move excludedMove;
         public Move[] quiets;
         public Move[] captures;
+        public int reduction;
         public int failHighCount;
         public boolean nullMoveAllowed = true;
     }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -213,6 +213,7 @@ public class Searcher implements Search {
         final SearchStackEntry prev = ss.get(ply - 1);
         final Move excludedMove = curr.excludedMove;
         final boolean singularSearch = excludedMove != null;
+        final int priorReduction = rootNode || singularSearch ? 0 : prev.reduction;
 
         history.getKillerTable().clear(ply + 1);
         ss.get(ply + 2).failHighCount = 0;
@@ -298,7 +299,7 @@ public class Searcher implements Search {
         // Decrease LMR reduction in hindsight if the static evaluation gets better (credit to Reckless)
         if (!inCheck
                 && !rootNode
-                && prev.reduction >= 3
+                && priorReduction >= 3
                 && staticEval + prev.staticEval < 0) {
             depth++;
         }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -213,7 +213,6 @@ public class Searcher implements Search {
         final SearchStackEntry prev = ss.get(ply - 1);
         final Move excludedMove = curr.excludedMove;
         final boolean singularSearch = excludedMove != null;
-        final int priorReduction = rootNode || singularSearch ? 0 : prev.reduction;
 
         history.getKillerTable().clear(ply + 1);
         ss.get(ply + 2).failHighCount = 0;
@@ -299,7 +298,7 @@ public class Searcher implements Search {
         // Decrease LMR reduction in hindsight if the static evaluation gets better (credit to Reckless)
         if (!inCheck
                 && !rootNode
-                && priorReduction >= 3
+                && prev.reduction >= 3
                 && staticEval + prev.staticEval < 0) {
             depth++;
         }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -295,6 +295,16 @@ public class Searcher implements Search {
         }
         curr.staticEval = staticEval;
 
+        // Increase LMR reduction in hindsight if the static evaluation gets worse (credit to Reckless)
+        if (!inCheck
+                && depth >= 2
+                && !rootNode
+                && prev.reduction >= 1
+                && prev.staticEval != Integer.MIN_VALUE
+                && staticEval + prev.staticEval > 96) {
+            depth -= 1;
+        }
+
         // We are 'improving' if the static eval of the current position is greater than it was on our previous turn.
         // If our position is improving we can be more aggressive in our beta pruning - where the eval is too high - but
         // should be more cautious in our alpha pruning - where the eval is too low.
@@ -536,7 +546,9 @@ public class Searcher implements Search {
             }
             else {
                 // For all other moves, search with a null window.
+                curr.reduction = reduction;
                 score = -search(depth - 1 - reduction + extension, ply + 1, -alpha - 1, -alpha, !cutNode);
+                curr.reduction = 0;
 
                 if (score > alpha && (score < beta || reduction > 0)) {
                     // If the score beats alpha, we need to do a re-search with the full window and depth.

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -295,14 +295,12 @@ public class Searcher implements Search {
         }
         curr.staticEval = staticEval;
 
-        // Increase LMR reduction in hindsight if the static evaluation gets worse (credit to Reckless)
+        // Decrease LMR reduction in hindsight if the static evaluation gets better (credit to Reckless)
         if (!inCheck
-                && depth >= 2
                 && !rootNode
-                && prev.reduction >= 1
-                && prev.staticEval != Integer.MIN_VALUE
-                && staticEval + prev.staticEval > 96) {
-            depth -= 1;
+                && prev.reduction >= 3
+                && staticEval + prev.staticEval < 0) {
+            depth++;
         }
 
         // We are 'improving' if the static eval of the current position is greater than it was on our previous turn.

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -295,10 +295,12 @@ public class Searcher implements Search {
         }
         curr.staticEval = staticEval;
 
-        // Decrease LMR reduction in hindsight if the static evaluation gets better (credit to Reckless)
+        // Hindsight extension
+        // If we reduced search depth in the parent node, but now the static eval indicates the position is improving,
+        // we reduce the parent node's reduction 'in hindsight' by extending search depth in the current node.
         if (!inCheck
                 && !rootNode
-                && prev.reduction >= 3
+                && prev.reduction >= config.hindsightExtLimit()
                 && staticEval + prev.staticEval < 0) {
             depth++;
         }


### PR DESCRIPTION
Idea taken from Reckless (in turn taken from Stockfish)

If we reduced the previous node by a lot, and then the static eval indicates the opponent's position improves, correct the reduction in hindsight by extending depth by 1.

```
Elo   | 3.37 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 14120 W: 3393 L: 3256 D: 7471
Penta | [69, 1668, 3480, 1743, 100]
```
https://kelseyde.pythonanywhere.com/test/524/

bench 5421436