### PR TITLE
Clamp all scores to [Score.MIN, Score.MAX] range

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Score.java
+++ b/src/main/java/com/kelseyde/calvin/search/Score.java
@@ -17,7 +17,7 @@ public class Score {
     }
 
     public static boolean isDefined(int score) {
-        return Math.abs(score) != Score.MAX;
+        return score >= -Score.MATE && score <= Score.MATE;
     }
 
     /**

--- a/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
+++ b/src/test/java/com/kelseyde/calvin/tables/TranspositionTableTest.java
@@ -3,6 +3,7 @@ package com.kelseyde.calvin.tables;
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.board.Move;
 import com.kelseyde.calvin.board.Piece;
+import com.kelseyde.calvin.search.Score;
 import com.kelseyde.calvin.tables.tt.HashEntry;
 import com.kelseyde.calvin.tables.tt.HashFlag;
 import com.kelseyde.calvin.tables.tt.TranspositionTable;
@@ -52,7 +53,7 @@ public class TranspositionTableTest {
         Board board = FEN.parse("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23").toBoard();
         long zobristKey = board.getState().getKey();
         int depth = 1;
-        int score = 1000000;
+        int score = Score.MATE;
         int flag = HashFlag.UPPER;
         Move move = Move.fromUCI("e2e4");
         assertEntry(zobristKey, score, move, flag, depth, true);
@@ -63,7 +64,7 @@ public class TranspositionTableTest {
         Board board = FEN.parse("3r1r1k/pQ1b2pp/4p1q1/2p1b3/2B2p2/2N1B2P/PPP2PP1/3R1RK1 w - - 0 23").toBoard();
         long zobristKey = board.getState().getKey();
         int depth = 1;
-        int score = -1000000;
+        int score = -Score.MATE;
         int flag = HashFlag.UPPER;
         Move move = Move.fromUCI("e2e4");
         assertEntry(zobristKey, score, move, flag, depth, false);
@@ -131,7 +132,7 @@ public class TranspositionTableTest {
 
         board.makeMove(TestUtils.getLegalMove(board, "g8", "f6"));
         flag = HashFlag.LOWER;
-        eval = 1000000;
+        eval = Score.MATE;
         depth = 10;
         table.put(board.getState().getKey(), flag, depth, ply + 2, null, 0,  eval, true);
 
@@ -209,13 +210,13 @@ public class TranspositionTableTest {
         int plyRemaining = 10;
         int plyFromRoot = 0;
 
-        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  1000000, true);
+        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0, Score.MATE, true);
 
-        Assertions.assertEquals(1000000, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(Score.MATE, table.get(board.getState().getKey(), 0).score());
 
-        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0,  -1000000, false);
+        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0,  -Score.MATE, false);
 
-        Assertions.assertEquals(-1000000, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(-Score.MATE, table.get(board.getState().getKey(), 0).score());
 
     }
 
@@ -227,13 +228,13 @@ public class TranspositionTableTest {
         int plyRemaining = 10;
         int plyFromRoot = 1;
 
-        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  1000000, true);
+        table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0, Score.MATE, true);
 
-        Assertions.assertEquals(999999, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(Score.MATE - 1, table.get(board.getState().getKey(), 0).score());
 
-        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0,  -1000000, false);
+        table.put(board.getState().getKey(), flag, plyRemaining + 1, plyFromRoot, bestMove, 0, -Score.MATE, false);
 
-        Assertions.assertEquals(-999999, table.get(board.getState().getKey(), 0).score());
+        Assertions.assertEquals(-Score.MATE + 1, table.get(board.getState().getKey(), 0).score());
 
     }
 
@@ -243,18 +244,18 @@ public class TranspositionTableTest {
         long zobrist = board.getState().getKey();
         int flag = HashFlag.EXACT;
         Move bestMove = Move.fromUCI("e7e8b");
-        int eval = 1000000;
+        int eval = Score.MATE;
         int plyRemaining = 10;
         int plyFromRoot = 5;
 
         table.put(board.getState().getKey(), flag, plyRemaining, plyFromRoot, bestMove, 0,  eval, true);
 
-        Assertions.assertEquals(1000000, table.get(zobrist, 5).score());
-        Assertions.assertEquals(999999, table.get(zobrist, 4).score());
-        Assertions.assertEquals(999998, table.get(zobrist, 3).score());
-        Assertions.assertEquals(999997, table.get(zobrist, 2).score());
-        Assertions.assertEquals(999996, table.get(zobrist, 1).score());
-        Assertions.assertEquals(999995, table.get(zobrist, 0).score());
+        Assertions.assertEquals(Score.MATE, table.get(zobrist, 5).score());
+        Assertions.assertEquals(Score.MATE - 1, table.get(zobrist, 4).score());
+        Assertions.assertEquals(Score.MATE - 2, table.get(zobrist, 3).score());
+        Assertions.assertEquals(Score.MATE - 3, table.get(zobrist, 2).score());
+        Assertions.assertEquals(Score.MATE - 4, table.get(zobrist, 1).score());
+        Assertions.assertEquals(Score.MATE - 5, table.get(zobrist, 0).score());
     }
 
     @Test


### PR DESCRIPTION
Instead of initialising scores/evals to `Integer.MIN_VALUE`, use `Score.MIN` instead.

```
Elo   | 0.66 +- 3.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 14146 W: 3369 L: 3342 D: 7435
Penta | [66, 1668, 3596, 1659, 84]
```
https://kelseyde.pythonanywhere.com/test/529/

bench 5094420