### PR TITLE
Don't do hindsight extensions twice, or in check

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -213,6 +213,7 @@ public class Searcher implements Search {
         final SearchStackEntry prev = ss.get(ply - 1);
         final Move excludedMove = curr.excludedMove;
         final boolean singularSearch = excludedMove != null;
+        final int priorReduction = rootNode || singularSearch ? 0 : prev.reduction;
 
         history.getKillerTable().clear(ply + 1);
         ss.get(ply + 2).failHighCount = 0;
@@ -300,7 +301,8 @@ public class Searcher implements Search {
         // we reduce the parent node's reduction 'in hindsight' by extending search depth in the current node.
         if (!inCheck
                 && !rootNode
-                && prev.reduction >= config.hindsightExtLimit()
+                && priorReduction >= config.hindsightExtLimit()
+                && prev.staticEval != Integer.MIN_VALUE
                 && staticEval + prev.staticEval < 0) {
             depth++;
         }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -302,7 +302,7 @@ public class Searcher implements Search {
         if (!inCheck
                 && !rootNode
                 && priorReduction >= config.hindsightExtLimit()
-                && prev.staticEval != Integer.MIN_VALUE
+                && Score.isDefined(prev.staticEval)
                 && staticEval + prev.staticEval < 0) {
             depth++;
         }


### PR DESCRIPTION
Passed non-reg.

We were accidentally applying hindsight extensions a second time in singular search. And, we we were accidentally checking the stack staticEval when it was a check node (so the static eval was `Score.MIN`)

```
Elo   | 5.06 +- 5.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 4460 W: 1090 L: 1025 D: 2345
Penta | [26, 495, 1123, 560, 26]
```
https://kelseyde.pythonanywhere.com/test/541/

bench 5402845