### PR TITLE
Complexity LMR

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -66,7 +66,7 @@ public class EngineConfig {
     private final Tunable lmrFailHighCount       = new Tunable("LmrCutoffCount", 1024, 0, 2048, 150);
     private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3037, 1536, 6144, 1000);
     private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3122, 1536, 6144, 1000);
-    private final Tunable lmrComplexityDivisor   = new Tunable("LmrComplexityDivisor", 2048, 1024, 4096, 512);
+    private final Tunable lmrComplexityDivisor   = new Tunable("LmrComplexityDivisor", 6144, 1536, 8192, 512);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
     private final Tunable lmpBase                = new Tunable("LmpBase", 0, 0, 50, 10);
     private final Tunable lmpScale               = new Tunable("LmpScale", 40, 10, 80, 10);

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -66,6 +66,7 @@ public class EngineConfig {
     private final Tunable lmrFailHighCount       = new Tunable("LmrCutoffCount", 1024, 0, 2048, 150);
     private final Tunable lmrQuietHistoryDiv     = new Tunable("LmrQuietHistoryDiv", 3037, 1536, 6144, 1000);
     private final Tunable lmrNoisyHistoryDiv     = new Tunable("LmrNoisyHistoryDiv", 3122, 1536, 6144, 1000);
+    private final Tunable lmrComplexityDivisor   = new Tunable("LmrComplexityDivisor", 2048, 1024, 4096, 512);
     private final Tunable lmpDepth               = new Tunable("LmpDepth", 8, 0, 16, 1);
     private final Tunable lmpBase                = new Tunable("LmpBase", 0, 0, 50, 10);
     private final Tunable lmpScale               = new Tunable("LmpScale", 40, 10, 80, 10);
@@ -134,7 +135,7 @@ public class EngineConfig {
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
-                lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit
+                lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit, lmrComplexityDivisor
         );
     }
 
@@ -382,6 +383,10 @@ public class EngineConfig {
 
     public int lmrNoisyHistoryDiv() {
         return lmrNoisyHistoryDiv.value;
+    }
+
+    public int lmrComplexityDivisor() {
+        return lmrComplexityDivisor.value;
     }
 
     public int lmpDepth() {

--- a/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchHistory.java
@@ -109,6 +109,14 @@ public class SearchHistory {
         return correction / CorrectionHistoryTable.SCALE;
     }
 
+    public int squaredCorrectionTerms(Board board, SearchStack ss, int ply) {
+        int pawn    = pawnCorrHistTable.get(board.pawnKey(), board.isWhite());
+        int white   = nonPawnCorrHistTables[Colour.WHITE].get(board.nonPawnKeys()[Colour.WHITE], board.isWhite());
+        int black   = nonPawnCorrHistTables[Colour.BLACK].get(board.nonPawnKeys()[Colour.BLACK], board.isWhite());
+        int counter = getContCorrHistEntry(ss, ply, board.isWhite());
+        return pawn * pawn + white * white + black * black + counter * counter;
+    }
+
     public void updateCorrectionHistory(Board board, SearchStack ss, int ply, int depth, int score, int staticEval) {
         pawnCorrHistTable.update(board.pawnKey(), board.isWhite(), depth, score, staticEval);
         nonPawnCorrHistTables[Colour.WHITE].update(board.nonPawnKeys()[Colour.WHITE], board.isWhite(), depth, score, staticEval);


### PR DESCRIPTION
Idea from Pawnocchio author @JonathanHallstrom. Reduce less in nodes where the correction history indicates the position is likely complex.

```
Elo   | 9.38 +- 5.93 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3262 W: 787 L: 699 D: 1776
Penta | [3, 341, 862, 415, 10]
```
https://kelseyde.pythonanywhere.com/test/560/

bench 6488865