### PR TITLE
Reduce depth on alpha raise

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -90,6 +90,8 @@ public class EngineConfig {
     private final Tunable seDoubleExtMargin      = new Tunable("SeDoubleExtMargin", 20, 0, 32, 5);
     private final Tunable ttExtensionDepth       = new Tunable("TtExtDepth", 6, 0, 12, 1);
     private final Tunable hindsightExtLimit      = new Tunable("HindsightExtensionLimit", 3, 2, 5, 1);
+    private final Tunable alphaReductionMinDepth = new Tunable("AlphaReductionMinDepth", 2, 0, 6, 1);
+    private final Tunable alphaReductionMaxDepth = new Tunable("AlphaReductionMaxDepth", 12, 8, 16, 1);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
     private final Tunable quietHistMalusMax      = new Tunable("QuietHistMalusMax", 1200, 100, 2000, 100);
@@ -139,7 +141,7 @@ public class EngineConfig {
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
                 lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit, lmrFutileMargin, lmrFutileScale, lmrFutileHistDivisor,
-                lmrComplexityDivisor
+                lmrComplexityDivisor, alphaReductionMinDepth, alphaReductionMaxDepth
         );
     }
 
@@ -483,6 +485,14 @@ public class EngineConfig {
 
     public int hindsightExtLimit() {
         return hindsightExtLimit.value;
+    }
+
+    public int alphaReductionMinDepth() {
+        return alphaReductionMinDepth.value;
+    }
+
+    public int alphaReductionMaxDepth() {
+        return alphaReductionMaxDepth.value;
     }
 
     public int quietHistBonusMax() {

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -594,6 +594,15 @@ public class Searcher implements Search {
                     curr.failHighCount++;
                     break;
                 }
+
+                // Alpha raise reduction
+                // It is unlikely that multiple moves raise alpha, therefore, if we have already raised alpha, we can
+                // reduce the search depth for the remaining moves.
+                if (depth > config.alphaReductionMinDepth()
+                        && depth < config.alphaReductionMaxDepth()
+                        && !Score.isMate(score)) {
+                    depth--;
+                }
             }
         }
 


### PR DESCRIPTION
```
Elo   | 6.20 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 6052 W: 1522 L: 1414 D: 3116
Penta | [40, 678, 1491, 768, 49]
```
https://kelseyde.pythonanywhere.com/test/568/

bench 4821829