### PR TITLE
Dynamic policy move ordering

### DIFF
--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -86,6 +86,9 @@ public class EngineConfig {
     private final Tunable seDoubleExtMargin      = new Tunable("SeDoubleExtMargin", 20, 0, 32, 5);
     private final Tunable ttExtensionDepth       = new Tunable("TtExtDepth", 6, 0, 12, 1);
     private final Tunable hindsightExtLimit      = new Tunable("HindsightExtensionLimit", 3, 2, 5, 1);
+    private final Tunable quietOrderingMult      = new Tunable("QuietOrderingMult", 5, 0, 20, 2);
+    private final Tunable quietOrderingMin       = new Tunable("QuietOrderingMult", -50, -100, 0, 25);
+    private final Tunable quietOrderingMax       = new Tunable("QuietOrderingMax", 100, 75, 200, 25);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
     private final Tunable quietHistMalusMax      = new Tunable("QuietHistMalusMax", 1200, 100, 2000, 100);
@@ -134,7 +137,8 @@ public class EngineConfig {
                 softTimeScaleMax, uciOverhead, bmStabilityMinDepth, scoreStabilityMinDepth, seeNoisyDivisor,
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
-                lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit
+                lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit, quietOrderingMult, quietOrderingMin,
+                quietOrderingMax
         );
     }
 
@@ -462,6 +466,18 @@ public class EngineConfig {
 
     public int hindsightExtLimit() {
         return hindsightExtLimit.value;
+    }
+
+    public int quietOrderingMult() {
+        return quietOrderingMult.value;
+    }
+
+    public int quietOrderingMin() {
+        return quietOrderingMin.value;
+    }
+
+    public int quietOrderingMax() {
+        return quietOrderingMax.value;
     }
 
     public int quietHistBonusMax() {

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -92,9 +92,9 @@ public class EngineConfig {
     private final Tunable hindsightExtLimit      = new Tunable("HindsightExtensionLimit", 3, 2, 5, 1);
     private final Tunable alphaReductionMinDepth = new Tunable("AlphaReductionMinDepth", 2, 0, 6, 1);
     private final Tunable alphaReductionMaxDepth = new Tunable("AlphaReductionMaxDepth", 12, 8, 16, 1);
-    private final Tunable quietOrderingMult      = new Tunable("QuietOrderingMult", 10, 0, 20, 2);
-    private final Tunable quietOrderingMin       = new Tunable("QuietOrderingMin", -100, -100, 0, 25);
-    private final Tunable quietOrderingMax       = new Tunable("QuietOrderingMax", 200, 75, 200, 25);
+    private final Tunable dynamicPolicyMult      = new Tunable("DynamicPolicyMult", 10, 0, 20, 2);
+    private final Tunable dynamicPolicyMin       = new Tunable("DynamicPolicyMin", -100, -100, 0, 25);
+    private final Tunable dynamicPolicyMax       = new Tunable("DynamicPolicyMax", 200, 75, 200, 25);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
     private final Tunable quietHistMalusMax      = new Tunable("QuietHistMalusMax", 1200, 100, 2000, 100);
@@ -144,8 +144,8 @@ public class EngineConfig {
                 seeQsNoisyDivisor, seeQsNoisyOffset, lmrQuietHistoryDiv, lmrNoisyHistoryDiv, seDepth, seTtDepthMargin,
                 seBetaMargin, seReductionOffset, seReductionDivisor, seDoubleExtMargin, aspWideningFactor, fpMoveMultiplier,
                 lmpImpBase, lmpImpScale, lmrFailHighCount, hindsightExtLimit, lmrFutileMargin, lmrFutileScale, lmrFutileHistDivisor,
-                lmrComplexityDivisor, alphaReductionMinDepth, alphaReductionMaxDepth, quietOrderingMult, quietOrderingMin,
-                quietOrderingMax
+                lmrComplexityDivisor, alphaReductionMinDepth, alphaReductionMaxDepth, dynamicPolicyMult, dynamicPolicyMin,
+                dynamicPolicyMax
         );
     }
 
@@ -499,16 +499,16 @@ public class EngineConfig {
         return alphaReductionMaxDepth.value;
     }
 
-    public int quietOrderingMult() {
-        return quietOrderingMult.value;
+    public int dynamicPolicyMult() {
+        return dynamicPolicyMult.value;
     }
 
-    public int quietOrderingMin() {
-        return quietOrderingMin.value;
+    public int dynamicPolicyMin() {
+        return dynamicPolicyMin.value;
     }
 
-    public int quietOrderingMax() {
-        return quietOrderingMax.value;
+    public int dynamicPolicyMax() {
+        return dynamicPolicyMax.value;
     }
 
     public int quietHistBonusMax() {

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -92,9 +92,9 @@ public class EngineConfig {
     private final Tunable hindsightExtLimit      = new Tunable("HindsightExtensionLimit", 3, 2, 5, 1);
     private final Tunable alphaReductionMinDepth = new Tunable("AlphaReductionMinDepth", 2, 0, 6, 1);
     private final Tunable alphaReductionMaxDepth = new Tunable("AlphaReductionMaxDepth", 12, 8, 16, 1);
-    private final Tunable quietOrderingMult      = new Tunable("QuietOrderingMult", 5, 0, 20, 2);
-    private final Tunable quietOrderingMin       = new Tunable("QuietOrderingMin", -50, -100, 0, 25);
-    private final Tunable quietOrderingMax       = new Tunable("QuietOrderingMax", 100, 75, 200, 25);
+    private final Tunable quietOrderingMult      = new Tunable("QuietOrderingMult", 10, 0, 20, 2);
+    private final Tunable quietOrderingMin       = new Tunable("QuietOrderingMin", -100, -100, 0, 25);
+    private final Tunable quietOrderingMax       = new Tunable("QuietOrderingMax", 200, 75, 200, 25);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);
     private final Tunable quietHistMalusMax      = new Tunable("QuietHistMalusMax", 1200, 100, 2000, 100);

--- a/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
+++ b/src/main/java/com/kelseyde/calvin/engine/EngineConfig.java
@@ -87,7 +87,7 @@ public class EngineConfig {
     private final Tunable ttExtensionDepth       = new Tunable("TtExtDepth", 6, 0, 12, 1);
     private final Tunable hindsightExtLimit      = new Tunable("HindsightExtensionLimit", 3, 2, 5, 1);
     private final Tunable quietOrderingMult      = new Tunable("QuietOrderingMult", 5, 0, 20, 2);
-    private final Tunable quietOrderingMin       = new Tunable("QuietOrderingMult", -50, -100, 0, 25);
+    private final Tunable quietOrderingMin       = new Tunable("QuietOrderingMin", -50, -100, 0, 25);
     private final Tunable quietOrderingMax       = new Tunable("QuietOrderingMax", 100, 75, 200, 25);
     private final Tunable quietHistBonusMax      = new Tunable("QuietHistBonusMax", 1200, 100, 2000, 100);
     private final Tunable quietHistBonusScale    = new Tunable("QuietHistBonusScale", 200, 50, 400, 25);

--- a/src/main/java/com/kelseyde/calvin/search/SearchStack.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchStack.java
@@ -36,6 +36,8 @@ public class SearchStack {
         public Move[] captures;
         public int reduction;
         public int failHighCount;
+        public boolean quiet;
+        public boolean inCheck;
         public boolean nullMoveAllowed = true;
     }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -213,6 +213,7 @@ public class Searcher implements Search {
         final SearchStackEntry prev = ss.get(ply - 1);
         final Move excludedMove = curr.excludedMove;
         final boolean singularSearch = excludedMove != null;
+        curr.inCheck = inCheck;
 
         history.getKillerTable().clear(ply + 1);
         ss.get(ply + 2).failHighCount = 0;
@@ -296,6 +297,17 @@ public class Searcher implements Search {
             }
         }
         curr.staticEval = staticEval;
+
+        if (!inCheck
+                && !singularSearch
+                && !rootNode
+                && prev.move != null
+                && prev.quiet
+                && Score.isDefined(prev.staticEval)) {
+            int value = config.quietOrderingMult() * -(staticEval + prev.staticEval);
+            int bonus = clamp(value, config.quietOrderingMin(), config.quietOrderingMax());
+            history.getQuietHistoryTable().add(prev.move, prev.piece, !board.isWhite(), bonus);
+        }
 
         // Hindsight extension
         // If we reduced search depth in the parent node, but now the static eval indicates the position is improving,
@@ -527,7 +539,7 @@ public class Searcher implements Search {
 
             // We have decided that the current move should not be pruned and is worth searching further.
             // Therefore, let's make the move on the board and search the resulting position.
-            makeMove(move, piece, captured, curr);
+            makeMove(scoredMove, piece, captured, curr);
 
             if (isCapture && captureMoves < 16) {
                 curr.captures[captureMoves++] = move;
@@ -673,6 +685,9 @@ public class Searcher implements Search {
 
         final boolean inCheck = movegen.isCheck(board);
 
+        SearchStackEntry curr = ss.get(ply);
+        curr.inCheck = inCheck;
+
         MoveFilter filter;
 
         // Re-use cached static eval if available. Don't compute static eval while in check.
@@ -710,8 +725,6 @@ public class Searcher implements Search {
 
         final QuiescentMovePicker movePicker = new QuiescentMovePicker(config, movegen, ss, history, board, ply, ttMove, inCheck);
         movePicker.setFilter(filter);
-
-        SearchStackEntry sse = ss.get(ply);
 
         int movesSearched = 0;
 
@@ -751,12 +764,12 @@ public class Searcher implements Search {
             if (!inCheck && !recapture && !SEE.see(board, move, config.qsSeeThreshold()))
                 continue;
 
-            makeMove(move, piece, captured, sse);
+            makeMove(scoredMove, piece, captured, curr);
 
             td.nodes++;
             final int score = -quiescenceSearch(-beta, -alpha, ply + 1);
 
-            unmakeMove(sse);
+            unmakeMove(curr);
 
             if (score > bestScore) {
                 bestScore = score;
@@ -805,10 +818,11 @@ public class Searcher implements Search {
         // do nothing as this implementation is single-threaded
     }
 
-    private void makeMove(Move move, Piece piece, Piece captured, SearchStackEntry sse) {
-        eval.makeMove(board, move);
-        board.makeMove(move);
-        sse.move = move;
+    private void makeMove(ScoredMove move, Piece piece, Piece captured, SearchStackEntry sse) {
+        eval.makeMove(board, move.move());
+        board.makeMove(move.move());
+        sse.move = move.move();
+        sse.quiet = move.isQuiet();
         sse.piece = piece;
         sse.captured = captured;
     }
@@ -927,6 +941,10 @@ public class Searcher implements Search {
                 (ttEntry.flag() == HashFlag.EXACT ||
                 (ttEntry.flag() == HashFlag.LOWER && ttEntry.score() >= rawStaticEval) ||
                 (ttEntry.flag() == HashFlag.UPPER && ttEntry.score() <= rawStaticEval));
+    }
+
+    private int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
     }
 
 }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -314,8 +314,8 @@ public class Searcher implements Search {
                 && prev.move != null
                 && prev.quiet
                 && Score.isDefined(prev.staticEval)) {
-            int value = config.quietOrderingMult() * -(staticEval + prev.staticEval);
-            int bonus = clamp(value, config.quietOrderingMin(), config.quietOrderingMax());
+            int value = config.dynamicPolicyMult() * -(staticEval + prev.staticEval);
+            int bonus = clamp(value, config.dynamicPolicyMin(), config.dynamicPolicyMax());
             history.getQuietHistoryTable().add(prev.move, prev.piece, !board.isWhite(), bonus);
         }
 

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -306,7 +306,8 @@ public class Searcher implements Search {
         }
         curr.staticEval = staticEval;
 
-        // Use the difference between the static eval in the current node and parent node to improve move ordering.
+        // Dynamic policy
+        // Use the difference between the static eval in the current node and parent node to update quiet history.
         if (!inCheck
                 && !singularSearch
                 && !rootNode

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -298,6 +298,7 @@ public class Searcher implements Search {
         }
         curr.staticEval = staticEval;
 
+        // Use the difference between the static eval in the current node and parent node to improve move ordering.
         if (!inCheck
                 && !singularSearch
                 && !rootNode

--- a/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
+++ b/src/main/java/com/kelseyde/calvin/tables/history/QuietHistoryTable.java
@@ -26,6 +26,13 @@ public class QuietHistoryTable extends AbstractHistoryTable {
         table[colourIndex][piece.index()][move.to()] = update;
     }
 
+    public void add(Move move, Piece piece, boolean white, int bonus) {
+        int colourIndex = Colour.index(white);
+        short current = table[colourIndex][piece.index()][move.to()];
+        short update = gravity(current, (short) bonus);
+        table[colourIndex][piece.index()][move.to()] = update;
+    }
+
     public short get(Move move, Piece piece, boolean white) {
         int colourIndex = Colour.index(white);
         return table[colourIndex][piece.index()][move.to()];


### PR DESCRIPTION
Idea from Viz (Stockfish)

Use diff between static eval in current node and parent node to improve quiet move ordering

```
Elo   | 6.59 +- 4.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 4.00]
Games | N: 6646 W: 1660 L: 1534 D: 3452
Penta | [42, 750, 1626, 850, 55]
```
https://kelseyde.pythonanywhere.com/test/582/

bench 3938982

