### PR TITLE
Use static eval in LMP threshold

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -487,7 +487,7 @@ public class Searcher implements Search {
 
             // Late Move Pruning
             // Skip quiet moves ordered very late in the list.
-            final int lateMoveThreshold = lateMoveThreshold(depth, improving);
+            final int lateMoveThreshold = lateMoveThreshold(depth, improving || staticEval >= beta);
             if (!pvNode
                     && !rootNode
                     && isQuiet
@@ -940,9 +940,9 @@ public class Searcher implements Search {
                 + (historyScore / config.lmrFutileHistDivisor());
     }
 
-    private int lateMoveThreshold(int depth, boolean improving) {
-        final int base = improving ? config.lmpImpBase() : config.lmpBase();
-        final int scale = improving ? config.lmpImpScale() : config.lmpScale();
+    private int lateMoveThreshold(int depth, boolean optimistic) {
+        final int base = optimistic ? config.lmpImpBase() : config.lmpBase();
+        final int scale = optimistic ? config.lmpImpScale() : config.lmpScale();
         return (base + depth * scale) / 10;
     }
 


### PR DESCRIPTION
Idea from Reckless.

```
Elo   | 1.99 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 4.00]
Games | N: 40100 W: 9774 L: 9544 D: 20782
Penta | [266, 4768, 9755, 4992, 269]
```
https://kelseyde.pythonanywhere.com/test/672/

