### PR TITLE
Fix JIT bench slowdown

### DIFF
--- a/src/main/java/com/kelseyde/calvin/uci/UCI.java
+++ b/src/main/java/com/kelseyde/calvin/uci/UCI.java
@@ -46,6 +46,8 @@ public class UCI {
 
         // Allow the engine to be benched from the command line at startup.
         if (args.length == 1 && args[0].equals("bench")) {
+            // We run bench twice because JIT stuff drastically slows down the first run.
+            // Therefore, we discard the initial results and take the NPS of the second run.
             Bench.run(ENGINE, false, false);
             Bench.run(ENGINE, true, true);
         }

--- a/src/main/java/com/kelseyde/calvin/uci/UCI.java
+++ b/src/main/java/com/kelseyde/calvin/uci/UCI.java
@@ -46,7 +46,8 @@ public class UCI {
 
         // Allow the engine to be benched from the command line at startup.
         if (args.length == 1 && args[0].equals("bench")) {
-            // We run bench twice because JIT stuff drastically slows down the first couple of runs.
+            // Let me unpack this insanity:
+            // We run bench three times because JIT stuff drastically slows down the first couple of runs.
             // Therefore, we discard the initial results and take the NPS of the third run.
             Bench.run(ENGINE, false, false);
             Bench.run(ENGINE, false, false);

--- a/src/main/java/com/kelseyde/calvin/uci/UCI.java
+++ b/src/main/java/com/kelseyde/calvin/uci/UCI.java
@@ -344,4 +344,5 @@ public class UCI {
         }
     }
 
+
 }

--- a/src/main/java/com/kelseyde/calvin/uci/UCI.java
+++ b/src/main/java/com/kelseyde/calvin/uci/UCI.java
@@ -46,8 +46,9 @@ public class UCI {
 
         // Allow the engine to be benched from the command line at startup.
         if (args.length == 1 && args[0].equals("bench")) {
-            // We run bench twice because JIT stuff drastically slows down the first run.
-            // Therefore, we discard the initial results and take the NPS of the second run.
+            // We run bench twice because JIT stuff drastically slows down the first couple of runs.
+            // Therefore, we discard the initial results and take the NPS of the third run.
+            Bench.run(ENGINE, false, false);
             Bench.run(ENGINE, false, false);
             Bench.run(ENGINE, true, true);
         }

--- a/src/main/java/com/kelseyde/calvin/uci/UCI.java
+++ b/src/main/java/com/kelseyde/calvin/uci/UCI.java
@@ -46,7 +46,8 @@ public class UCI {
 
         // Allow the engine to be benched from the command line at startup.
         if (args.length == 1 && args[0].equals("bench")) {
-            Bench.run(ENGINE, true);
+            Bench.run(ENGINE, false, false);
+            Bench.run(ENGINE, true, true);
         }
 
         try (Scanner in = new Scanner(System.in)) {
@@ -90,7 +91,7 @@ public class UCI {
     }
 
     public static void handleBench(UCICommand command) {
-        Bench.run(ENGINE, false);
+        Bench.run(ENGINE, false, true);
     }
 
     public static void handleNewGame(UCICommand command) {

--- a/src/main/java/com/kelseyde/calvin/utils/Bench.java
+++ b/src/main/java/com/kelseyde/calvin/utils/Bench.java
@@ -70,7 +70,7 @@ public class Bench {
 
     private static final int BENCH_DEPTH = 14;
 
-    public static void run(Engine engine, boolean exit) {
+    public static void run(Engine engine, boolean exit, boolean print) {
 
         UCI.setOutputEnabled(false);
         GoCommand command = new GoCommand(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE,
@@ -93,10 +93,12 @@ public class Bench {
 
         long nps = (nodes / time) * 1000;
         UCI.setOutputEnabled(true);
-        UCI.write(String.format("%s nodes %s nps", nodes, nps));
-        if (exit) {
+
+        if (print)
+            UCI.write(String.format("%s nodes %s nps", nodes, nps));
+
+        if (exit)
             UCI.handleQuit(null);
-        }
 
     }
 


### PR DESCRIPTION
Thanks to @JonathanHallstrom for finally discovering the root cause of Calvin's bench issues. JIT stuff causes the initial call to bench() to slow to a crawl. By re-running a couple times and taking the third result, it produces a more sane NPS output.

bench 3529980