### PR TITLE
Calculate PV distance differently

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/SearchStack.java
+++ b/src/main/java/com/kelseyde/calvin/search/SearchStack.java
@@ -26,7 +26,6 @@ public class SearchStack {
     }
 
     public static class SearchStackEntry {
-        public boolean pvNode;
         public int staticEval;
         public Move move;
         public Piece piece;
@@ -37,6 +36,7 @@ public class SearchStack {
         public Move[] captures;
         public int reduction;
         public int failHighCount;
+        public int pvDistance;
         public boolean quiet;
         public boolean inCheck;
     }

--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -202,7 +202,7 @@ public class Searcher implements Search {
         final Move excludedMove = curr.excludedMove;
         final boolean singularSearch = excludedMove != null;
         final int priorReduction = rootNode || singularSearch ? 0 : prev.reduction;
-        curr.pvNode = pvNode;
+        curr.pvDistance = pvNode ? 0 : prev.pvDistance + 1;
         curr.inCheck = inCheck;
 
         history.getKillerTable().clear(ply + 1);
@@ -385,9 +385,6 @@ public class Searcher implements Search {
 
         }
 
-        // How many plies away from the nearest parent PV-node are we?
-        int distanceFromPv = pvNode ? 0 : distanceFromPv(ply);
-
         // We have decided that the current node should not be pruned and is worth examining further.
         // Now we begin iterating through the legal moves in the position and searching deeper in the tree.
 
@@ -436,7 +433,7 @@ public class Searcher implements Search {
                 r -= ttPv ? config.lmrPvNode() : 0;
                 r += cutNode ? config.lmrCutNode() : 0;
                 r += !improving ? config.lmrNotImproving() : 0;
-                r += Math.min(distanceFromPv * config.lmrPvDistanceMult(), config.lmrPvDistanceMax());
+                r += Math.min(curr.pvDistance * config.lmrPvDistanceMult(), config.lmrPvDistanceMax());
                 r -= historyScore / (isQuiet ? config.lmrQuietHistoryDiv() : config.lmrNoisyHistoryDiv()) * 1024;
                 r += staticEval + lmrFutilityMargin(depth, historyScore) <= alpha ? config.lmrFutile() : 0;
                 r += !rootNode && prev.failHighCount > 2 ? config.lmrFailHighCount() : 0;
@@ -714,8 +711,9 @@ public class Searcher implements Search {
         final boolean inCheck = movegen.isCheck(board);
 
         SearchStackEntry curr = ss.get(ply);
+        SearchStackEntry prev = ss.get(ply - 1);
         curr.inCheck = inCheck;
-        curr.pvNode = pvNode;
+        curr.pvDistance = pvNode ? 0 : prev.pvDistance + 1;
 
         // Re-use cached static eval if available. Don't compute static eval while in check.
         int rawStaticEval = Score.MIN;
@@ -901,16 +899,6 @@ public class Searcher implements Search {
         if (ply > 3 && Score.isDefined(ss.get(ply - 4).staticEval))
             return staticEval > ss.get(ply - 4).staticEval;
         return true;
-    }
-
-    private int distanceFromPv(int ply) {
-        int distance = 1;
-        for (; distance < ply; distance++) {
-            if (ss.get(ply - distance).pvNode) {
-                break;
-            }
-        }
-        return distance;
     }
 
     private SearchResult handleNoLegalMoves() {


### PR DESCRIPTION
Quick non-reg, merging early but whatever

```
Elo   | 0.51 +- 4.25 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 1.16 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 8210 W: 2063 L: 2051 D: 4096
Penta | [93, 949, 1993, 993, 77]
```
https://kelseyde.pythonanywhere.com/test/759/

bench 3232954
