### PR TITLE
Don't penalise moves that raise alpha

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -545,11 +545,6 @@ public class Searcher implements Search {
             // Therefore, let's make the move on the board and search the resulting position.
             makeMove(scoredMove, piece, captured, curr);
 
-            if (isCapture && captureMoves < 16)
-                curr.captures[captureMoves++] = move;
-            else if (quietMoves < 16)
-                curr.quiets[quietMoves++] = move;
-
             final int nodesBefore = td.nodes;
             td.nodes++;
 
@@ -595,6 +590,16 @@ public class Searcher implements Search {
 
             if (shouldStop(HARD)) {
                 return alpha;
+            }
+
+            if (score <= alpha || score >= beta) {
+                // Only give a history bonus to moves that cause a cut-off, and a penalty
+                // to moves that fail to raise alpha. Ignore moves that raise alpha but
+                // do not cause a cut-off.
+                if (isCapture && captureMoves < 16)
+                    curr.captures[captureMoves++] = move;
+                else if (quietMoves < 16)
+                    curr.quiets[quietMoves++] = move;
             }
 
             if (score > bestScore) {

--- a/src/main/java/com/kelseyde/calvin/utils/Bench.java
+++ b/src/main/java/com/kelseyde/calvin/utils/Bench.java
@@ -68,7 +68,7 @@ public class Bench {
             "2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93"
     );
 
-    private static final int BENCH_DEPTH = 14;
+    private static final int BENCH_DEPTH = 12;
 
     public static void run(Engine engine, boolean exit, boolean print) {
 

--- a/src/main/java/com/kelseyde/calvin/utils/Bench.java
+++ b/src/main/java/com/kelseyde/calvin/utils/Bench.java
@@ -99,7 +99,6 @@ public class Bench {
 
         if (exit)
             UCI.handleQuit(null);
-
     }
 
 }


### PR DESCRIPTION
Idea from obsidian author gabe.

```
Elo   | 3.41 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 4.00]
Games | N: 15506 W: 3887 L: 3735 D: 7884
Penta | [113, 1763, 3838, 1937, 102]
```
https://kelseyde.pythonanywhere.com/test/784/

bench 1218894