### PR TITLE
Scale aspiration window based on previous expansions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -83,6 +83,7 @@ public class Searcher implements Search {
         int reduction = 0;
         int maxReduction = config.aspMaxReduction();
         int window = config.aspDelta();
+        int windowExpansions = 0;
 
         while (!shouldStop(SOFT) && td.depth < Search.MAX_DEPTH) {
 
@@ -114,6 +115,7 @@ public class Searcher implements Search {
                     beta = (alpha + beta) / 2;
                     alpha -= window;
                     window = window * config.aspWideningFactor() / 100;
+                    windowExpansions++;
                     reduction = 0;
                     continue;
                 }
@@ -121,12 +123,14 @@ public class Searcher implements Search {
                     // If score >= beta, re-search with an expanded aspiration window
                     beta += window;
                     window = window * config.aspWideningFactor() / 100;
+                    windowExpansions++;
                     reduction = Math.min(maxReduction, reduction + 1);
                     continue;
                 }
 
                 // Center the aspiration window around the score from the current iteration, to be used next time.
-                window = config.aspDelta();
+                windowExpansions /= 2;
+                window = config.aspDelta() + 6 * (windowExpansions >= 4 ? 1 : 0);
                 alpha = score - window;
                 beta = score + window;
             }


### PR DESCRIPTION
```
Elo   | 1.63 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 4.00]
Games | N: 57018 W: 14198 L: 13930 D: 28890
Penta | [268, 6262, 15252, 6388, 339]
```
https://kelseyde.pythonanywhere.com/test/798/

bench 1315283