### PR TITLE
More negative extensions

### DIFF
--- a/src/main/java/com/kelseyde/calvin/search/Searcher.java
+++ b/src/main/java/com/kelseyde/calvin/search/Searcher.java
@@ -540,9 +540,11 @@ public class Searcher implements Search {
                     else
                         extension = 1;
                 }
+                else if (ttEntry.score() >= beta)
+                    extension = -3;
                 else if (cutNode)
                     extension = -2;
-                else if (ttEntry.score() >= beta)
+                else if (ttEntry.score() <= alpha)
                     extension = -1;
 
             }


### PR DESCRIPTION
```
Elo   | 2.75 +- 2.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 4.00]
Games | N: 21074 W: 5277 L: 5110 D: 10687
Penta | [113, 2443, 5280, 2566, 135]
```
https://chess.n9x.co/test/2248/

bench 1206809